### PR TITLE
Add missing packages to Sphinx

### DIFF
--- a/pkgs/sphinx.yaml
+++ b/pkgs/sphinx.yaml
@@ -1,5 +1,6 @@
 extends: [distutils_package]
 dependencies:
+  build: [distribute, docutils, jinja2, pygments]
   run: [docutils, jinja2, pygments]
 
 sources:


### PR DESCRIPTION
Without these, the sphinx install will automatically download them from the
internet, which is the last thing we want.
