### PR TITLE
Travis: Use debian.yaml in packages2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: python
 env:
 #  - TEST_PROFILE="test.packages1.yaml"
-#  - TEST_PROFILE="test.packages2.yaml"
+  - TEST_PROFILE="test.packages2.yaml"
 #  - TEST_PROFILE="test.packages3.yaml"
   - TEST_PROFILE="test.host-scipy.yaml"
 python:

--- a/tests/test.packages2.yaml
+++ b/tests/test.packages2.yaml
@@ -1,7 +1,7 @@
 # Tests some general configuration of packages
 
 extends:
-- file: linux.yaml
+- file: debian.yaml
 
 packages:
 


### PR DESCRIPTION
This should fix the problem of:

[ERROR] /home/travis/build/hashdist/hashstack2/pkgs/host-mpi.yaml, line 6:
Tried to substitute undefined parameter "HOST_MPIEXEC"
