### PR TITLE
Update Tornado to 3.1.1

### DIFF
--- a/pkgs/tornado.yaml
+++ b/pkgs/tornado.yaml
@@ -4,5 +4,5 @@ dependencies:
   run: [python]
 
 sources:
-  - url: https://pypi.python.org/packages/source/t/tornado/tornado-3.0.1.tar.gz
-    key: tar.gz:duhrhxytlc5i6birx4ws66zm65flwrxu
+  - url: https://pypi.python.org/packages/source/t/tornado/tornado-3.1.1.tar.gz
+    key: tar.gz:grmqjp7eudhf22dsap3yhgdkoph5pxb2


### PR DESCRIPTION
This is needed for the IPython Notebook from master.
