### PR TITLE
Travis: Periodically update the terminal

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ python:
   - 2.7
 before_install:
   - sudo apt-get update -qq
-  - sudo apt-get install gfortran
+  - sudo apt-get install gfortran pv
   - if [[ "${TEST_PROFILE}" == "test.packages1.yaml" ]]; then
       sudo apt-get install liblapack-dev;
     fi
@@ -26,6 +26,8 @@ install:
   - export PATH=`pwd`/hashdist/bin:$PATH
 script:
   - cp tests/$TEST_PROFILE $TEST_PROFILE
-  - hit build -p $TEST_PROFILE
+  - set -o pipefail
+  - hit build -p $TEST_PROFILE -v 2>&1 | pv -i 15 -n | cat > log.txt
+  - tail -n 60 log.txt
 notifications:
   email: false


### PR DESCRIPTION
- Enables "-v" for hit build (so that we can see full output)
- Saves the output from hit into log.txt
- Runs "pv" with 15 second intervals to keep Travis happy (this fixes a bug
  when some packages take more than 10 min to build)
- At the end we show the last 60 lines of log.txt for debugging

This should be enough to show most of the failures, yet Travis should be able
to finish the whole build even for very long logs.
