### PR TITLE
[WIP] Fixes rpath in openssl

### DIFF
--- a/pkgs/openssl.yaml
+++ b/pkgs/openssl.yaml
@@ -7,9 +7,16 @@ sources:
     key: tar.gz:65hrl2gi74i2upk3wxzhnuqc5qmnojdo
 
 build_stages:
-- name: configure
-  mode: replace
-  handler: bash
-  bash: |
-    #./config --prefix=$ARTIFACT shared zlib-dynamic -I$ZLIB_DIR/include -Wl,-rpath=$ARTIFACT/lib -Wl,-rpath=$ZLIB_DIR/lib
-    ./config --prefix=$ARTIFACT shared zlib-dynamic -I$ZLIB_DIR/include
+
+  - when: platform == 'linux'
+    name: set_flags
+    before: configure
+    handler: bash
+    bash: |
+      export OPENSSL_EXTRA_FLAGS="-Wl,-rpath=$ARTIFACT/lib -Wl,-rpath=$ZLIB_DIR/lib"
+
+  - name: configure
+    mode: replace
+    handler: bash
+    bash: |
+      ./config --prefix=$ARTIFACT shared zlib-dynamic -I$ZLIB_DIR/include $OPENSSL_EXTRA_FLAGS

--- a/pkgs/openssl.yaml
+++ b/pkgs/openssl.yaml
@@ -1,6 +1,6 @@
 extends: [autotools_package]
 dependencies:
-  build: [zlib]
+  build: [zlib, patchelf]
 
 sources:
   - url: https://www.openssl.org/source/openssl-1.0.1e.tar.gz
@@ -20,3 +20,11 @@ build_stages:
     handler: bash
     bash: |
       ./config --prefix=$ARTIFACT shared zlib-dynamic -I$ZLIB_DIR/include $OPENSSL_EXTRA_FLAGS
+
+  - when: platform == 'linux'
+    name: fix_rpath
+    after: install
+    handler: bash
+    bash: |
+      $PATCHELF --set-rpath $ARTIFACT/lib:$ZLIB_DIR/lib $ARTIFACT/lib/engines/libgost.so
+


### PR DESCRIPTION
Before:
```
ondrej@kittiwake:~/repos/hashstack2(master)$ ~/repos/hashdist/bin/hit-check-libs rpath
Checking libs in 'rpath'...
Lib: rpath/lib/libssl.so
libcrypto.so.1.0.0 /lib/x86_64-linux-gnu/libcrypto.so.1.0.0 (0x00007f8a441d5000)

Lib: rpath/lib/libssl.so
libz.so.1 /lib/x86_64-linux-gnu/libz.so.1 (0x00007f8a439fa000)

Lib: rpath/lib/libssl.so.1.0.0
libcrypto.so.1.0.0 /lib/x86_64-linux-gnu/libcrypto.so.1.0.0 (0x00007faed3068000)

Lib: rpath/lib/libssl.so.1.0.0
libz.so.1 /lib/x86_64-linux-gnu/libz.so.1 (0x00007faed288d000)

Lib: rpath/lib/engines/libcswift.so
libcrypto.so.1.0.0 /lib/x86_64-linux-gnu/libcrypto.so.1.0.0 (0x00007fe670d7f000)

Lib: rpath/lib/engines/libcswift.so
libz.so.1 /lib/x86_64-linux-gnu/libz.so.1 (0x00007fe6705a4000)

Lib: rpath/lib/engines/libatalla.so
libcrypto.so.1.0.0 /lib/x86_64-linux-gnu/libcrypto.so.1.0.0 (0x00007f81d283e000)

Lib: rpath/lib/engines/libatalla.so
libz.so.1 /lib/x86_64-linux-gnu/libz.so.1 (0x00007f81d2063000)

Lib: rpath/lib/engines/lib4758cca.so
libcrypto.so.1.0.0 /lib/x86_64-linux-gnu/libcrypto.so.1.0.0 (0x00007f49e892a000)

Lib: rpath/lib/engines/lib4758cca.so
libz.so.1 /lib/x86_64-linux-gnu/libz.so.1 (0x00007f49e814f000)

Lib: rpath/lib/engines/libnuron.so
libcrypto.so.1.0.0 /lib/x86_64-linux-gnu/libcrypto.so.1.0.0 (0x00007f2be6e95000)

Lib: rpath/lib/engines/libnuron.so
libz.so.1 /lib/x86_64-linux-gnu/libz.so.1 (0x00007f2be66ba000)

Lib: rpath/lib/engines/libgost.so
libcrypto.so.1.0.0 /lib/x86_64-linux-gnu/libcrypto.so.1.0.0 (0x00007f0c4abea000)

Lib: rpath/lib/engines/libgost.so
libz.so.1 /lib/x86_64-linux-gnu/libz.so.1 (0x00007f0c4a40f000)

Lib: rpath/lib/engines/libubsec.so
libcrypto.so.1.0.0 /lib/x86_64-linux-gnu/libcrypto.so.1.0.0 (0x00007f1af2495000)

Lib: rpath/lib/engines/libubsec.so
libz.so.1 /lib/x86_64-linux-gnu/libz.so.1 (0x00007f1af1cba000)

Lib: rpath/lib/engines/libaep.so
libcrypto.so.1.0.0 /lib/x86_64-linux-gnu/libcrypto.so.1.0.0 (0x00007fd4349bf000)

Lib: rpath/lib/engines/libaep.so
libz.so.1 /lib/x86_64-linux-gnu/libz.so.1 (0x00007fd4341e4000)

Lib: rpath/lib/engines/libchil.so
libcrypto.so.1.0.0 /lib/x86_64-linux-gnu/libcrypto.so.1.0.0 (0x00007fbd63024000)

Lib: rpath/lib/engines/libchil.so
libz.so.1 /lib/x86_64-linux-gnu/libz.so.1 (0x00007fbd62849000)

Lib: rpath/lib/engines/libsureware.so
libcrypto.so.1.0.0 /lib/x86_64-linux-gnu/libcrypto.so.1.0.0 (0x00007f87dc578000)

Lib: rpath/lib/engines/libsureware.so
libz.so.1 /lib/x86_64-linux-gnu/libz.so.1 (0x00007f87dbd9d000)
```
After:
```
ondrej@kittiwake:~/repos/hashstack2(rpath)$ ~/repos/hashdist/bin/hit-check-libs rpath
Checking libs in 'rpath'...
```