### PR TITLE
Generalize hardcoded OSX_DEPLOYMENT_TARGET

### DIFF
--- a/osx.yaml
+++ b/osx.yaml
@@ -5,4 +5,4 @@ parameters:
   platform: Darwin
   PATH: /usr/bin:/bin:/usr/local/bin
   PROLOGUE: |
-    export MACOSX_DEPLOYMENT_TARGET=10.9
+    export MACOSX_DEPLOYMENT_TARGET=$(sw_vers -productVersion)


### PR DESCRIPTION
The OSX_DEPLOYMENT_TARGET in the osx.yaml base file is now set to the
current version of OS X on the host machine.  Note that this change to
the prologue script will trigger a full stack rebuild in hashstack.
