### PR TITLE
restored freetype dependency in matplotlib

### DIFF
--- a/examples/proteus.Cygwin.yaml
+++ b/examples/proteus.Cygwin.yaml
@@ -25,6 +25,8 @@ packages:
   blas:
     use: host-blas
   daetk:
+  freetype:
+    use: host-freetype
   mpi:
     use: host-mpi
   nose:

--- a/examples/proteus.Darwin.yaml
+++ b/examples/proteus.Darwin.yaml
@@ -24,6 +24,8 @@ packages:
   blas:
     use: host-osx-framework-accelerate
   daetk:
+  freetype:
+    use: host-freetype
   mpi:
     use: mpich
   nose:

--- a/pkgs/host-freetype.yaml
+++ b/pkgs/host-freetype.yaml
@@ -1,0 +1,2 @@
+when_build_dependency:
+  - {set: 'FREETYPE_LDFLAGS', value: '-lfreetype'}

--- a/pkgs/matplotlib.yaml
+++ b/pkgs/matplotlib.yaml
@@ -1,7 +1,7 @@
 extends: [distutils_package, libflags]
 dependencies:
-  build: [numpy, png]
-  run: [numpy, png]
+  build: [freetype, numpy, png]
+  run: [freetype, numpy, png]
 
 sources:
   - url: https://downloads.sourceforge.net/project/matplotlib/matplotlib/matplotlib-1.2.1/matplotlib-1.2.1.tar.gz


### PR DESCRIPTION
This undoes breakage I made in ef53ce529793701b90bb17816fb2733329967f21

Cygwin and Darwin should use host freetype, it should be built by default on Linux

Fixes: https://github.com/hashdist/hashstack2/issues/73
