### PR TITLE
removed mumps and hypre as dependencies because they are too fussy

### DIFF
--- a/examples/proteus.Darwin.yaml
+++ b/examples/proteus.Darwin.yaml
@@ -35,7 +35,7 @@ packages:
     build_with: |
       parmetis      
     download: |
-      superlu, superlu_dist, spooles, hypre, blacs, scalapack, mumps
+      superlu, superlu_dist
     coptflags: -O2
     link: shared
     debug: false


### PR DESCRIPTION
superlu and superlu_dist ought to be enough for a simple parallel installation
