### PR TITLE
link to openblas and not blas

### DIFF
--- a/pkgs/openblas.yaml
+++ b/pkgs/openblas.yaml
@@ -13,4 +13,4 @@ profile_links:
   link: '*/**/*'
 
 when_build_dependency:
-  - {set: 'BLAS_LDFLAGS', value: '-L${ARTIFACT}/lib -lblas'}
+  - {set: 'BLAS_LDFLAGS', value: '-L${ARTIFACT}/lib -lopenblas'}


### PR DESCRIPTION
I only did minor testing with petsc and it fails to link against petsc. I don't quite understand how the petsc package works to get openblas accepted as blas alternative for petsc.
