### PR TITLE
fix terminfo/tic hangs (build own programs in ncurses)

### DIFF
--- a/pkgs/ncurses/ncurses.yaml
+++ b/pkgs/ncurses/ncurses.yaml
@@ -15,6 +15,6 @@ build_stages:
   - name: configure
     mode: override
     extra: ['--with-shared', '--without-profile', '--without-debug',
-        '--without-ada', '--without-tests', '--without-progs',
-        '--with-ticlib=tic', '--with-termlib=tinfo']
+        '--without-ada', '--without-tests', '--with-ticlib=tic',
+        '--with-termlib=tinfo']
 


### PR DESCRIPTION
ncurses toolchain falls back to /usr/bin/tic to build terminfo database.

This was causing stalls when the system tic was incompatible with the
current version.
