### PR TITLE
Refactor Parmetis-CMake builds/dynamic link flags

### DIFF
--- a/pkgs/parmetis.yaml
+++ b/pkgs/parmetis.yaml
@@ -1,3 +1,5 @@
+extends: [base_package]
+
 dependencies:
   build: [cmake, mpi]
 
@@ -5,32 +7,50 @@ sources:
 - url: http://glaros.dtc.umn.edu/gkhome/fetch/sw/parmetis/parmetis-4.0.2.tar.gz
   key: tar.gz:llf3oahuk7j33j6uxokewvm5p4q7a5n3
 
+
 build_stages:
-- name: configure
+- name: setup_builddir
+  after: prologue
   handler: bash
   bash: |
-    cd metis
-    make config prefix=${ARTIFACT} shared=1
-    cd ..
-    make config prefix=${ARTIFACT} shared=1
+    mkdir -p _build_metis
+    mkdir -p _build_parmetis
+
+- name: configure
+  after: setup_builddir
+  handler: bash
+  bash: |
+    CMAKE_FLAGS="
+      -DCMAKE_VERBOSE_MAKEFILE=1
+      -DGKLIB_PATH=${BUILD}/metis/GKlib
+      -DCMAKE_INSTALL_PREFIX=${ARTIFACT}
+      -DSHARED=1
+      -DCMAKE_C_COMPILER=$MPICC
+      -DCMAKE_CXX_COMPILER=$MPICXX
+      -DCMAKE_EXE_LINKER_FLAGS={{DYNAMIC_EXE_LINKER_FLAGS}}"
+    (
+    cd _build_metis && cmake ${BUILD}/metis $CMAKE_FLAGS
+    )
+
+    (
+    cd _build_parmetis && cmake ${BUILD} $CMAKE_FLAGS \
+      -DMETIS_PATH=${BUILD}/metis
+    )
+
 
 - name: make
   after: configure
   handler: bash
   bash: |
-    cd metis
-    make -j ${HASHDIST_CPU_COUNT}
-    cd ..
-    make -j ${HASHDIST_CPU_COUNT}
+    make -C _build_metis -j ${HASHDIST_CPU_COUNT}
+    make -C _build_parmetis -j ${HASHDIST_CPU_COUNT}
 
 - name: install
   after: make
   handler: bash
   bash: |
-    cd metis
-    make install
-    cd ..
-    make install
+    make -C _build_metis install
+    make -C _build_parmetis install
 
 profile_links:
 - name: everything


### PR DESCRIPTION
Parmetis is really managed by a CMake build, and we need access to the
underlying CMake commands to inject specific build linking flags, as
needed on supercomputers such as the Cray XE6.

I've also added the ability to pass DYNAMIC_EXE_LINKER_FLAGS in to
the CMake build, an example flag needed for dynamic linking on the
Cray.
