### PR TITLE
Add Bitcoin Package

### DIFF
--- a/pkgs/bitcoin.yaml
+++ b/pkgs/bitcoin.yaml
@@ -1,3 +1,5 @@
+extends: [base_package]
+
 dependencies:
   build: [berkeleydb, boost]
 


### PR DESCRIPTION
It seems to be working, except it doesn't install into the profile, see the last comment below for details.

Here is the makefile that is used: https://github.com/bitcoin/bitcoin/blob/03a7d673876dc8fbae876290b455c02b0cac80bd/src/makefile.unix one just has to declare the proper variables.

Here is documentation how to build it: https://github.com/bitcoin/bitcoin/blob/03a7d673876dc8fbae876290b455c02b0cac80bd/doc/build-unix.md

Apparently this has changed in the latest bitcoin git master (not yet released), they use autotools.
