### PR TITLE
[WIP] 64-bit support for Proteus

### DIFF
--- a/examples/proteus.linux2-64.yaml
+++ b/examples/proteus.linux2-64.yaml
@@ -1,0 +1,52 @@
+# This profile file controls your <#> (HashDist) build environment.
+
+# In the future, we'll provide better incorporation of
+# automatic environment detection.  For now, have a look
+# at the YAML files in the top-level directory and choose
+# the most *specific* file that matches your environment.
+
+extends:
+- file: debian.yaml
+
+# The packages list specifies all the packages that you
+# require installed.  <#> will ensure that all packages
+# and their dependencies are installed when you build this
+# profile.
+
+parameters:
+  index_width: 64
+
+packages:
+
+  launcher:
+  cmake:
+    use: host-cmake
+  python:
+    host: false
+    build_with: |
+      bzip2, sqlite
+  blas:
+    use: host-blas
+  daetk:
+  mpi:
+    use: mpich
+  nose:
+  hdf5:
+  ipython:
+  matplotlib:
+  petsc:
+    build_with: |
+      parmetis
+    download: |
+      hypre, blacs, scalapack
+    coptflags: -O2
+    link: shared
+    debug: false
+  petsc4py:
+    with_conf: true
+  pytables:
+  sphinx:
+  superlu:
+  sympy:
+  tetgen:
+  triangle:

--- a/pkgs/parmetis/parmetis-32-to-64.patch
+++ b/pkgs/parmetis/parmetis-32-to-64.patch
@@ -1,0 +1,12 @@
+diff --unified -r parmetis-4.0.2/metis/include/metis.h parmetis-4.0.2-64/metis/include/metis.h
+--- parmetis-4.0.2/metis/include/metis.h	2014-01-15 17:40:21.000000000 -0500
++++ parmetis-4.0.2-64/metis/include/metis.h	2014-01-15 17:40:46.000000000 -0500
+@@ -30,7 +30,7 @@
+  GCC does provides these definitions in stdint.h, but it may require some
+  modifications on other architectures.
+ --------------------------------------------------------------------------*/
+-#define IDXTYPEWIDTH 32
++#define IDXTYPEWIDTH 64
+ 
+ 
+ /*--------------------------------------------------------------------------

--- a/pkgs/parmetis/parmetis.yaml
+++ b/pkgs/parmetis/parmetis.yaml
@@ -9,6 +9,15 @@ sources:
 
 
 build_stages:
+- when: index_width == 64
+  name: switch_indices_from_32_to_64
+  files: [parmetis-32-to-64.patch]
+  before: setup_builddir
+  handler: bash
+  bash: |
+    patch -p1 < _hashdist/parmetis-32-to-64.patch
+
+
 - name: setup_builddir
   after: prologue
   handler: bash

--- a/pkgs/petsc/petsc.py
+++ b/pkgs/petsc/petsc.py
@@ -43,6 +43,10 @@ def configure(ctx, stage_args):
         conf_lines.append('--with-blas-dir=$BLAS_DIR')
         conf_lines.append('--with-lapack-dir=$LAPACK_DIR')
 
+    index_width = ctx.parameters.get('index_width', 32)
+    if index_width == 64:
+        conf_lines.append('--with-64-bit-indices')
+
     # Special case, ParMETIS also provides METIS 
     if 'PARMETIS' in ctx.dependency_dir_vars:
         conf_lines.append('--with-metis-dir=$PARMETIS_DIR')


### PR DESCRIPTION
This adds 64-bit support to the PETSc and Parmetis builds.  64-bit
support still needs to be added to DAETK and Proteus itself before this
code is fully functional.
