### PR TITLE
Update fenics packages to 1.3.0.

### DIFF
--- a/pkgs/dolfin/dolfin.yaml
+++ b/pkgs/dolfin/dolfin.yaml
@@ -18,8 +18,8 @@ dependencies:
   run: [ply]
 
 sources:
-- url: https://bitbucket.org/fenics-project/dolfin.git
-  key: git:9d8322e4d66e6c136d6955fd0b70c78f88f5aa79
+- url: https://bitbucket.org/fenics-project/dolfin/downloads/dolfin-1.3.0.tar.gz
+  key: tar.gz:ozm5ohbcbchvbug5rc4bdgdha7z5ggf6
 
 build_stages: 
 - name: configure ## See dolfin.py for details

--- a/pkgs/ffc.yaml
+++ b/pkgs/ffc.yaml
@@ -3,8 +3,8 @@ dependencies:
   build: [numpy]
 
 sources:
-- url: https://bitbucket.org/fenics-project/ffc.git
-  key: git:e43faa028ae6f3493e5e4e1d33b1da9d6bb85bb8
+- url: https://bitbucket.org/fenics-project/ffc/downloads/ffc-1.3.0.tar.gz
+  key: tar.gz:6qqvuiin4rolx3w5kytafgocrt433fic
 
 when_build_dependency:
 - prepend_path: PATH

--- a/pkgs/fiat.yaml
+++ b/pkgs/fiat.yaml
@@ -1,5 +1,5 @@
 extends: [distutils_package]
 
 sources:
-- url: https://bitbucket.org/fenics-project/fiat.git
-  key: git:f110663e4bcee8dad41f42da7c0805b51341b449
+- url: https://bitbucket.org/fenics-project/fiat/downloads/fiat-1.3.0.tar.gz
+  key: tar.gz:oshf2nmcdvi6sdg4oxowlvo7gyu3plh7

--- a/pkgs/instant.yaml
+++ b/pkgs/instant.yaml
@@ -1,5 +1,5 @@
 extends: [distutils_package]
 
 sources:
-- url: https://bitbucket.org/fenics-project/instant.git
-  key: git:91daa8d35a2e8e3cd1efcd8e87acd8b063627a7c
+- url: https://bitbucket.org/fenics-project/instant/downloads/instant-1.3.0.tar.gz
+  key: tar.gz:jjy5q3yv3thqrqc63ld7wdsb3kx5zmxa

--- a/pkgs/ufc.yaml
+++ b/pkgs/ufc.yaml
@@ -3,8 +3,8 @@ dependencies:
   build: [python, swig, boost]
 
 sources:
-- url: https://bitbucket.org/fenics-project/ufc.git
-  key: git:51a9a520e62845ef01509f1af2da9d010917c4f0
+- url: https://bitbucket.org/fenics-project/ufc/downloads/ufc-2.3.0.tar.gz
+  key: tar.gz:4wgaam6c6slxme5lqwl4n24qb7phspbc
 
 build_stages:
 - name: configure

--- a/pkgs/ufl.yaml
+++ b/pkgs/ufl.yaml
@@ -1,5 +1,5 @@
 extends: [distutils_package]
 
 sources:
-- url: https://bitbucket.org/fenics-project/ufl.git
-  key: git:571866775dcccd0dd3c68fde3a9c18b744fbb667
+- url: https://bitbucket.org/fenics-project/ufl/downloads/ufl-1.3.0.tar.gz
+  key: tar.gz:rwdalbmtflc7b2vv3dayoqmnz7u5su45


### PR DESCRIPTION
This will update the fenics packages to the latest 1.3.0 releases (ufc is updated to version 2.3.0).
