### PR TITLE
Add missing PKG_CONFIG_EXECUTABLE in pkg-config package.

### DIFF
--- a/pkgs/pkg-config.yaml
+++ b/pkgs/pkg-config.yaml
@@ -11,3 +11,5 @@ build_stages:
 when_build_dependency:
 - prepend_path: PATH
   value: '${ARTIFACT}/bin'
+- set: PKG_CONFIG_EXECUTABLE
+  value: '${ARTIFACT}/bin/pkg-config'


### PR DESCRIPTION
This sets `PKG_CONFIG_EXECUTABLE` in the `pkg-config` package. This is used in `dolfin`.
