### PR TITLE
fixed broken config on darwin due to share/dynamic libs

### DIFF
--- a/pkgs/daetk/arch.darwin
+++ b/pkgs/daetk/arch.darwin
@@ -1,6 +1,6 @@
 include ${PETSC}/conf/variables
 PREFIX=${ARTIFACT}
-ARCHIVE_SUFFIX = .a
+ARCHIVE_SUFFIX = .dylib
 
 #setup options/compilers using petsc configuration
 

--- a/pkgs/daetk/archive.darwin
+++ b/pkgs/daetk/archive.darwin
@@ -1,2 +1,2 @@
 $(ARCHIVE): $(OBJS) $(OBJS_ADD)
-	    $(AR) $(ARFLAGS) $(ARCHIVE) $(OBJS) $(OBJS_ADD)
+	    $(CXX) -dynamiclib $(LDFLAGS) $(OBJS) $(OBJS_ADD) $(LDLIBS) -o $(ARCHIVE)

--- a/pkgs/daetk/daetk.yaml
+++ b/pkgs/daetk/daetk.yaml
@@ -54,7 +54,7 @@ build_stages:
   after: make
   bash: |
     mkdir $ARTIFACT/lib
-    cp libdaetk.so $ARTIFACT/lib
+    cp libdaetk.* $ARTIFACT/lib
     mkdir $ARTIFACT/include
     cp *.h $ARTIFACT/include
     cp -r pete/pete-2.1.0/src/PETE $ARTIFACT/include


### PR DESCRIPTION
I accidentally pushed s shared library config for linux without setting up something similar for darwin. This adds a build of libdaetk.dylib and copies all the libdaetk.\* during install.
