### PR TITLE
add sys.platform-matched defaults

### DIFF
--- a/cygwin.yaml
+++ b/cygwin.yaml
@@ -12,3 +12,8 @@ parameters:
   HOST_PYTHON: /usr/bin/python
   HOST_PKG_CONFIG_EXECUTABLE: /usr/bin/pkgconfig
   HOST_SWIG_EXECUTABLE: /usr/bin/swig
+
+packages:
+  blas:
+    use: host-blas
+  ipython:

--- a/darwin.yaml
+++ b/darwin.yaml
@@ -1,0 +1,13 @@
+extends:
+ - file: common.yaml
+
+parameters:
+  platform: Darwin
+  PATH: /usr/bin:/bin:/usr/sbin:/sbin:/usr/local/bin
+  PROLOGUE: |
+    export MACOSX_DEPLOYMENT_TARGET=$(sw_vers -productVersion | sed "s/\(10.[0-9]\).*/\1/")
+
+packages:
+  blas:
+    use: host-osx-framework-accelerate
+  ipython:

--- a/linux2.yaml
+++ b/linux2.yaml
@@ -1,0 +1,7 @@
+extends:
+  - file: linux.yaml
+
+packages:
+  blas:
+    use: openblas
+  ipython:


### PR DESCRIPTION
These files specify the substrate that most scientific Python programs
need.  The user isn't required to use these, but it will help them write
portable programs that have a chance of installing on other machines.
