### PR TITLE
[WIP] Proteus on HashStack

### DIFF
--- a/examples/just.proteus.Darwin.yaml
+++ b/examples/just.proteus.Darwin.yaml
@@ -1,0 +1,17 @@
+# This profile file controls your <#> (HashDist) build environment.
+
+# In the future, we'll provide better incorporation of
+# automatic environment detection.  For now, have a look
+# at the YAML files in the top-level directory and choose
+# the most *specific* file that matches your environment.
+
+extends:
+ - file: darwin.yaml
+
+# The packages list specifies all the packages that you
+# require installed.  <#> will ensure that all packages
+# and their dependencies are installed when you build this
+# profile.
+
+packages:
+  proteus:

--- a/pkgs/proteus/config.py.hashstack
+++ b/pkgs/proteus/config.py.hashstack
@@ -1,0 +1,54 @@
+import os
+
+def include(package):
+    return os.path.join(os.getenv(package.upper()+'_DIR'), 'include')
+
+def lib(package):
+    return os.path.join(os.getenv(package.upper()+'_DIR'), 'lib')
+
+
+PROTEUS_INCLUDE_DIR = os.path.join(os.getenv('PROTEUS_PREFIX'), 'include')
+PROTEUS_LIB_DIR = os.path.join(os.getenv('PROTEUS_PREFIX'), 'lib')
+
+PROTEUS_EXTRA_COMPILE_ARGS= ['-Wall']
+
+mac_target = os.getenv('MACOSX_DEPLOYMENT_TARGET')
+if mac_target:
+    PROTEUS_EXTRA_COMPILE_ARGS += ['-I/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX'+ mac_target+ '.sdk/System/Library/Frameworks/Accelerate.framework/Versions/A/Frameworks/vecLib.framework/Versions/A/Headers/']
+
+PROTEUS_EXTRA_LINK_ARGS=['']
+PROTEUS_EXTRA_FC_COMPILE_ARGS= ['-Wall']
+PROTEUS_EXTRA_FC_LINK_ARGS=['']
+
+PROTEUS_SUPERLU_INCLUDE_DIR = include('superlu')
+PROTEUS_SUPERLU_H   = r'"slu_ddefs.h"'
+PROTEUS_SUPERLU_LIB_DIR = lib('superlu')
+PROTEUS_SUPERLU_LIB = 'superlu_4.1'
+
+PROTEUS_BLAS_INCLUDE_DIR = '.'
+PROTEUS_BLAS_H     = r'"cblas.h"'
+PROTEUS_BLAS_LIB_DIR = '.'
+PROTEUS_BLAS_LIB   = 'm'
+
+PROTEUS_LAPACK_INCLUDE_DIR = '.'
+PROTEUS_LAPACK_H   = r'"clapack.h"'
+PROTEUS_LAPACK_LIB_DIR = '.'
+PROTEUS_LAPACK_LIB = 'm'
+PROTEUS_LAPACK_INTEGER = '__CLPK_integer'
+
+PROTEUS_TRIANGLE_INCLUDE_DIR = include('triangle')
+PROTEUS_TRIANGLE_H = r'"triangle.h"'
+PROTEUS_TRIANGLE_LIB_DIR = lib('triangle')
+PROTEUS_TRIANGLE_LIB ='tri'
+
+PROTEUS_DAETK_INCLUDE_DIR = include('daetk')
+PROTEUS_DAETK_LIB_DIR = lib('daetk')
+PROTEUS_DAETK_LIB ='daetk'
+
+PROTEUS_MPI_INCLUDE_DIR = include('mpi')
+PROTEUS_MPI_LIB_DIR = lib('mpi')
+PROTEUS_MPI_LIBS =[]
+
+PROTEUS_PETSC_LIB_DIRS = []
+PROTEUS_PETSC_LIBS = []
+PROTEUS_PETSC_INCLUDE_DIRS = []

--- a/pkgs/proteus/proteus.yaml
+++ b/pkgs/proteus/proteus.yaml
@@ -1,0 +1,28 @@
+extends: [base_package]
+dependencies:
+  build: [daetk, lapack, mpi, python, numpy, cmake, cython, petsc4py, petsc, superlu, triangle]
+  run: [daetk, hdf5, lapack, ipython, matplotlib, nose, petsc, petsc4py, pytables, python, sphinx, superlu, sympy, tetgen, triangle]
+
+sources:
+  - url: https://github.com/erdc-cm/proteus
+    key: git:f414952cd5041348db915e40c371d42bfb8228cb
+
+
+build_stages:
+- name: configure
+  after: prologue
+  files: [config.py.hashstack]
+  handler: bash
+  bash: |
+    cp _hashdist/config.py.hashstack config.py
+
+
+- name: install
+  after: configure
+  handler: bash
+  bash: |
+    export PROTEUS_PREFIX=${ARTIFACT}
+    ${PYTHON} setuppyx.py install
+    ${PYTHON} setupf.py install
+    ${PYTHON} setuppetsc.py build --petsc-dir=${PETSC_DIR} --petsc-arch='' install
+    ${PYTHON} setup.py install


### PR DESCRIPTION
Hi Folks.

I'd appreciate a review or two on this one.  Notably, I'm not using the Proteus Makefile, I'm just calling the setup.py files directly, which I think should be supported.

Unfortunately, the Makefile is currently responsible for assembling the `bin/proteus`, `bin/proteus_env.sh` and version files.  I think this is waiting on a Proteus `setup.py` refactor that takes over responsibility more of the configuration and installation of Proteus, and eventually completely deprecating the Makefile.

Currently, this is only tested on Darwin, but should readily port to Linux and Cygwin.  I'll hold off on doing that work until people have had a chance to look at this.
