### PR TITLE
Defer to cmake to determine the correct build command.

### DIFF
--- a/base/cmake_package.yaml
+++ b/base/cmake_package.yaml
@@ -19,7 +19,7 @@ build_stages:
     after: configure
     handler: bash
     bash: |
-      make -j ${HASHDIST_CPU_COUNT}
+      cmake --build . -- -j ${HASHDIST_CPU_COUNT}
 
   - name: install
     after: make


### PR DESCRIPTION
Instead of presuming the build system is make when generating a cmake project
instead ask cmake to invoke the build system itself.
