### PR TITLE
Patch bzip2 to defer to the system cc compiler.

### DIFF
--- a/pkgs/bzip2/bzip2.yaml
+++ b/pkgs/bzip2/bzip2.yaml
@@ -10,13 +10,20 @@ sources:
 
 build_stages:
 
+- name: patch
+  before: make-configure
+  files: [clang-fix.patch]
+  handler: bash
+  bash: |
+    patch -up1 < _hashdist/clang-fix.patch
+
 - name: make-configure
   after: prologue
   handler: bash
-  when platform == 'linux':  
+  when platform == 'linux':
     bash: |
       make -f Makefile-libbz2_so
-  when platform == 'Darwin':  
+  when platform == 'Darwin':
     bash: |
       make -f Makefile
 

--- a/pkgs/bzip2/clang-fix.patch
+++ b/pkgs/bzip2/clang-fix.patch
@@ -1,0 +1,10 @@
+--- bzip2-1.0.6.orig/Makefile 2014-03-12 12:42:45.000000000 -0400
++++ bzip2-1.0.6/Makefile  2014-03-12 12:54:03.000000000 -0400
+@@ -15,7 +15,6 @@
+ SHELL=/bin/sh
+
+ # To assist in cross-compiling
+-CC=gcc
+ AR=ar
+ RANLIB=ranlib
+ LDFLAGS=


### PR DESCRIPTION
The bzip2 build system presumes that gcc is the default compiler no matter what.

Closes #146
