### PR TITLE
[WIP] Use CMAKE_POSITION_INDEPENDENT_CODE

### DIFF
--- a/pkgs/lapack.yaml
+++ b/pkgs/lapack.yaml
@@ -17,9 +17,10 @@ build_stages:
 - name: configure
   when compiler == 'gcc':
       extra: ['-D CMAKE_BUILD_TYPE:STRING=Release',
-              '-D CMAKE_Fortran_FLAGS_RELEASE:STRING="-O3 -fPIC -march=native -ffast-math -funroll-loops"',
+              '-D CMAKE_Fortran_FLAGS_RELEASE:STRING="-O3 -march=native -ffast-math -funroll-loops"',
               '-D CMAKE_INSTALL_RPATH:STRING="${ARTIFACT}/lib"',
               '-D CMAKE_INSTALL_RPATH_USE_LINK_PATH:BOOL=ON',
+              '-D CMAKE_POSITION_INDEPENDENT_CODE:BOOL=ON',
               '-D BUILD_TESTING:BOOL=OFF',
               '-D BUILD_SHARED_LIBS:BOOL=ON',
               ]
@@ -27,6 +28,7 @@ build_stages:
       extra: ['-D CMAKE_BUILD_TYPE:STRING=Release',
               '-D CMAKE_INSTALL_RPATH:STRING="${ARTIFACT}/lib"',
               '-D CMAKE_INSTALL_RPATH_USE_LINK_PATH:BOOL=ON',
+              '-D CMAKE_POSITION_INDEPENDENT_CODE:BOOL=ON',
               '-D BUILD_TESTING:BOOL=OFF',
               '-D BUILD_SHARED_LIBS:BOOL=ON',
               ]


### PR DESCRIPTION
Instead of hardwiring -fPIC into flags

TODO:
- [ ] check that `-fPIC` is there even after we set the release flags by hand for gfortran.
