### PR TITLE
curl hash was wrong

### DIFF
--- a/pkgs/curl.yaml
+++ b/pkgs/curl.yaml
@@ -2,4 +2,4 @@ extends: [autotools_package]
 
 sources:
   - url: http://curl.haxx.se/download/curl-7.33.0.tar.gz
-    key: tar.gz:4w36y5oqxgrgkxmndbkmjithrgrxbw4h
+    key: tar.gz:oriktrzl2j65rhogtfvovwxtkt5etpb4


### PR DESCRIPTION
When using the curl package I kept getting a key hash mismatch. Verified with hit fetch:

 ~/W/h/hashstack /qt_pkg> ../hashdist/bin/hit fetch http://curl.haxx.se/download/curl-7.33.0.tar.gz
Downloading http://curl.haxx.se/download/curl-7.33.0.tar.gz...
Downloading 'http://curl.haxx.se/download/curl-7.33.0.tar.gz'
[=========================] 100.0% (3.3MB of 3.3MB) 0.272MB/s ETA 0s  

tar.gz:oriktrzl2j65rhogtfvovwxtkt5etpb4
