### PR TITLE
Bump scientificpython version to 2.8.1.

### DIFF
--- a/pkgs/scientificpython.yaml
+++ b/pkgs/scientificpython.yaml
@@ -1,6 +1,8 @@
 extends: [distutils_package]
+dependencies:
+  build: [numpy]
+  run: [numpy]
 
 sources:
-  - url: http://sourcesup.cru.fr/frs/download.php/2309/ScientificPython-2.8.tar.gz
-    key: tar.gz:jxtmrunsqutnb4w3alzq5gncrkbub3sm
-
+- url: https://sourcesup.renater.fr/frs/download.php/4411/ScientificPython-2.8.1.tar.gz
+  key: tar.gz:3hxtkrzwief3wlul4m6loqz46yqrimd2


### PR DESCRIPTION
This also adds a build/run dependency on numpy.
