### PR TITLE
Add Clawpack + Git Submodule test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ env:
   - TEST_PROFILE="test.packages3.yaml"
   - TEST_PROFILE="test.packages4.yaml"
   - TEST_PROFILE="test.boost.yaml"
+  - TEST_PROFILE="test.clawpack.gitsubmodules.yaml"
   - TEST_PROFILE="test.host-scipy.yaml"
 python:
   - 2.7
@@ -22,6 +23,9 @@ before_install:
     fi
   - if [[ "${TEST_PROFILE}" == "test.boost.yaml" ]]; then
       sudo apt-get install mpich2;
+    fi
+  - if [[ "${TEST_PROFILE}" == "test.clawpack.gitsubmodules.yaml" ]]; then
+      sudo apt-get install liblapack-dev;
     fi
   - if [[ "${TEST_PROFILE}" == "test.host-scipy.yaml" ]]; then
       sudo apt-get install python-scipy;

--- a/tests/test.clawpack.gitsubmodules.yaml
+++ b/tests/test.clawpack.gitsubmodules.yaml
@@ -1,0 +1,12 @@
+extends:
+ - file: linux.yaml
+
+packages:
+  blas:
+    use: host-blas
+  python:
+    host: false
+    build_with: |
+      bzip2, openssl
+  clawpack:
+    github: https://github.com/clawpack/clawpack/commit/bd252ba6f835a255ca57cdc3b8848b31b550d428


### PR DESCRIPTION
Clawpack uses relative submodules, so it's a good test of our submodule
functionality.  This does not test the parallel aspects of Clawpack, but
this could be added by installing a PETSc installation.
