### PR TITLE
Make szip build in NoType mode, works around the liblibszip bug

### DIFF
--- a/pkgs/szip.yaml
+++ b/pkgs/szip.yaml
@@ -1,15 +1,17 @@
 extends: [cmake_package]
 
 sources:
-  - url: http://www.hdfgroup.org/ftp/lib-external/szip/2.1/src/szip-2.1.tar.gz
-    key: tar.gz:valnsxkwmlucpfrfvpn6u7iomikx27i7
+- url: http://www.hdfgroup.org/ftp/lib-external/szip/2.1/src/szip-2.1.tar.gz
+  key: tar.gz:valnsxkwmlucpfrfvpn6u7iomikx27i7
 
 build_stages:
+- name: configure
+  mode: override
+  extra: ['-DCMAKE_BUILD_TYPE:STRING=" "']
 
 - when: platform == 'Cygwin'
   name: configure
   handler: bash
   mode: replace
   bash: |
-    cmake -DCMAKE_INSTALL_PREFIX:PATH="$ARTIFACT" \
-      -DBUILD_SHARED_LIBS=true .
+    cmake -DBUILD_SHARED_LIBS=true .


### PR DESCRIPTION
:airquotes: fixes  #190 :airquotes:
