### PR TITLE
FFTW: build single precision as well

### DIFF
--- a/pkgs/fftw.yaml
+++ b/pkgs/fftw.yaml
@@ -8,4 +8,19 @@ sources:
 
 build_stages:
 - name: configure
-  extra: ['--enable-mpi', '--enable-sse2', '--enable-avx']
+  extra: ['--disable-debug', '--enable-shared', '--enable-mpi',
+          '--enable-sse2', '--enable-avx', '--enable-threads']
+
+- name: install
+  after: make
+  handler: bash
+  mode: override
+  bash: |
+    make install
+    make clean
+    # Build single precision library as well:
+    ./configure --prefix=$ARTIFACT --enable-single --disable-debug \
+            --enable-shared --enable-mpi --enable-sse2 --enable-avx \
+            --enable-threads
+    make -j ${HASHDIST_CPU_COUNT}
+    make install


### PR DESCRIPTION
This is needed for Julia. This follows Homebrew installation as well:

https://github.com/Homebrew/homebrew/blob/master/Library/Formula/fftw.rb

Also it enables threads.

It builds and seems to work.
But it's kind of a hack. @ahmadia if you have better ideas, that would be great.
