### PR TITLE
Doxygen

### DIFF
--- a/pkgs/doxygen.yaml
+++ b/pkgs/doxygen.yaml
@@ -1,5 +1,13 @@
 extends: [autotools_package]
 
+dependencies:
+  build: [bison]
+
 sources:
 - url: https://github.com/doxygen/doxygen.git
   key: git:1134237afe25f86fcf7c7e2a76a3542eee8acc79
+
+build_stages:
+  - name: configure
+    mode: override
+    extra: ['--bison=$BISON_DIR/bin/bison']


### PR DESCRIPTION
This also depends on flex. I happened to have flex installed:

```
$ which flex
/usr/bin/flex
```

But I think we might need to add it as an explicit dependency. Otherwise I tested it and it works for me.
