### PR TITLE
Tighten Proteus install

### DIFF
--- a/pkgs/proteus/proteus.yaml
+++ b/pkgs/proteus/proteus.yaml
@@ -1,11 +1,11 @@
-extends: [base_package]
+extends: [python_package]
 dependencies:
-  build: [daetk, lapack, mpi, python, numpy, cmake, cython, petsc4py, petsc, superlu, triangle]
+  build: [setuptools, daetk, lapack, mpi, python, numpy, cmake, cython, petsc4py, petsc, superlu, triangle]
   run: [daetk, hdf5, lapack, ipython, matplotlib, nose, petsc, petsc4py, pytables, python, sphinx, superlu, sympy, tetgen, triangle]
 
 sources:
   - url: https://github.com/erdc-cm/proteus
-    key: git:f414952cd5041348db915e40c371d42bfb8228cb
+    key: git:d5432ee27a6d4332d028d5be1db747e12e715ba0
 
 
 build_stages:
@@ -22,7 +22,45 @@ build_stages:
   handler: bash
   bash: |
     export PROTEUS_PREFIX=${ARTIFACT}
-    ${PYTHON} setuppyx.py install
-    ${PYTHON} setupf.py install
-    ${PYTHON} setuppetsc.py build --petsc-dir=${PETSC_DIR} --petsc-arch='' install
-    ${PYTHON} setup.py install
+    export PYTHONPATH=${ARTIFACT}/{{python_site_packages_rel}}:${PYTHONPATH}
+    mkdir -p ${ARTIFACT}/{{python_site_packages_rel}}
+    ${PYTHON} -c 'import setuptools; __file__="setuppyx.py"; execfile(__file__)' \
+       install \
+       --prefix=. --root=${ARTIFACT} \
+       --single-version-externally-managed
+    ${PYTHON} -c 'import setuptools; __file__="setupf.py"; execfile(__file__)' \
+       install \
+       --prefix=. --root=${ARTIFACT} \
+       --single-version-externally-managed
+    # work around petsc4py's no-arch PETSc detection issues
+    ${PYTHON} -c 'import setuptools; __file__="setuppetsc.py"; execfile(__file__)' \
+       build \
+       --petsc-dir=${PETSC_DIR} \
+       --petsc-arch=''\
+       install \
+       --prefix=. --root=${ARTIFACT} \
+       --single-version-externally-managed
+    ${PYTHON} -c 'import setuptools; __file__="setup.py"; execfile(__file__)' \
+       install \
+       --prefix=. --root=${ARTIFACT} \
+       --single-version-externally-managed
+
+- name: cleanup
+  after: install
+  handler: bash
+  bash: |
+        rm -rf ${ARTIFACT}/{{python_site_packages_rel}}/*.egg-info
+
+
+profile_links:
+
+  - name: python_packages
+    mode: replace
+    link: 'lib/python{{pyver}}/site-packages/proteus'
+    dirs: true
+
+  - name: python_exclude
+    mode: replace
+    after: python_packages
+    before: everything
+    exclude: 'lib/python{{pyver}}/site-packages'

--- a/pkgs/setuptools.yaml
+++ b/pkgs/setuptools.yaml
@@ -1,0 +1,12 @@
+extends: [distutils_package]
+
+build_stages:
+  - name: install
+    mode: override
+    handler: bash
+    bash: |
+      ${PYTHON} setup.py install --prefix=. --root=${ARTIFACT} --single-version-externally-managed
+
+sources:
+  - url: https://pypi.python.org/packages/source/s/setuptools/setuptools-3.4.3.tar.gz
+    key: tar.gz:yfr3o4jkjyuvq7cmwfn52gmjt7xmiopn


### PR DESCRIPTION
- Use setuptools externally-managed install to properly isolate install
  from Python
- Clean up egg files
- add needed setuptools.yaml package description
