### PR TITLE
[IDEA] Just use `python` from the $PATH?

### DIFF
--- a/base/distutils_package.yaml
+++ b/base/distutils_package.yaml
@@ -17,7 +17,7 @@ build_stages:
   after: setup_dirs
   handler: bash
   bash: |
-    ${PYTHON} setup.py install --prefix=${ARTIFACT}
+    python setup.py install --prefix=${ARTIFACT}
 
   # Remove easy_install pth files
 - name: cleanup

--- a/base/python_package.yaml
+++ b/base/python_package.yaml
@@ -16,7 +16,7 @@ build_stages:
   bash: |
     export PYTHONPATH=${ARTIFACT}/{{python_site_packages_rel}}:${PYTHONPATH}
     mkdir -p ${ARTIFACT}/{{python_site_packages_rel}}
-    ${PYTHON} -c 'import setuptools; __file__="setup.py"; execfile(__file__)' \
+    python -c 'import setuptools; __file__="setup.py"; execfile(__file__)' \
        install \
        --prefix=. --root=${ARTIFACT} \
        --single-version-externally-managed

--- a/pkgs/python/python.yaml
+++ b/pkgs/python/python.yaml
@@ -56,8 +56,6 @@ build_stages:
 
 
 when_build_dependency:
-  - set: PYTHON
-    value: ${ARTIFACT}/bin/python
   - prepend_path: PATH
     value: '${ARTIFACT}/bin'
 


### PR DESCRIPTION
Why cannot we just use `python` from the `PATH`? Like in this example PR.

That's how I detect which Python to use in cmake for example --- I just check for `python`. That's how `GMP` detects `m4` (see #217) --- it just looks it up in PATH. 

I noticed the `$PYTHON` is used for `python-host`. Does `python-host` work at all however?
