### PR TITLE
matplotlib v1.3.1 fixes for Cygwin

### DIFF
--- a/pkgs/matplotlib/fix_cxx_reserved_identifiers.patch
+++ b/pkgs/matplotlib/fix_cxx_reserved_identifiers.patch
@@ -1,0 +1,48 @@
+From 1215f78874127c27505616fcd73043991035dd7e Mon Sep 17 00:00:00 2001
+From: Ian Thomas <ianthomas23@gmail.com>
+Date: Wed, 25 Sep 2013 20:24:46 +0100
+Subject: [PATCH] Rename C++ variables to avoid use of reserved identifiers
+
+---
+ lib/matplotlib/tri/_tri.cpp | 6 +++---
+ lib/matplotlib/tri/_tri.h   | 2 +-
+ 2 files changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/lib/matplotlib/tri/_tri.cpp b/lib/matplotlib/tri/_tri.cpp
+index 9dd538a..8dbe107 100644
+--- a/lib/matplotlib/tri/_tri.cpp
++++ b/lib/matplotlib/tri/_tri.cpp
+@@ -2177,14 +2177,14 @@ TrapezoidMapTriFinder::Trapezoid::set_upper_right(Trapezoid* upper_right_)
+ 
+ 
+ RandomNumberGenerator::RandomNumberGenerator(unsigned long seed)
+-    : _M(21870), _A(1291), _C(4621), _seed(seed % _M)
++    : _m(21870), _a(1291), _c(4621), _seed(seed % _m)
+ {}
+ 
+ unsigned long
+ RandomNumberGenerator::operator()(unsigned long max_value)
+ {
+-    _seed = (_seed*_A + _C) % _M;
+-    return (_seed*max_value) / _M;
++    _seed = (_seed*_a + _c) % _m;
++    return (_seed*max_value) / _m;
+ }
+ 
+ 
+diff --git a/lib/matplotlib/tri/_tri.h b/lib/matplotlib/tri/_tri.h
+index 3662678..c923411 100644
+--- a/lib/matplotlib/tri/_tri.h
++++ b/lib/matplotlib/tri/_tri.h
+@@ -818,7 +818,7 @@ public:
+     unsigned long operator()(unsigned long max_value);
+ 
+ private:
+-    const unsigned long _M, _A, _C;
++    const unsigned long _m, _a, _c;
+     unsigned long _seed;
+ };
+ 
+-- 
+1.8.4.1
+

--- a/pkgs/matplotlib/matplotlib.yaml
+++ b/pkgs/matplotlib/matplotlib.yaml
@@ -15,6 +15,16 @@ build_stages:
   bash: |
     export PKG_CONFIG_PATH="$PNG_DIR/lib/pkgconfig:$FREETYPE_DIR/lib/pkgconfig"
 
+
+# This patch did not go into v1.3.1 :(
+- when: platform == 'Cygwin'
+  name: fix_cxx_reserved_identifiers
+  files: [fix_cxx_reserved_identifiers.patch]
+  before: install
+  handler: bash
+  bash: |
+    patch -p1 < _hashdist/fix_cxx_reserved_identifiers.patch
+
 - name: libflags
   before: install
 


### PR DESCRIPTION
This patch didn't land into Cygwin.  Shouldn't affect Linux builds so I'm going to merge this one in.
