### PR TITLE
fix broken PCRE url

### DIFF
--- a/pkgs/pcre.yaml
+++ b/pkgs/pcre.yaml
@@ -1,7 +1,7 @@
 extends: [autotools_package]
 
 sources:
-  - url: http://downloads.sourceforge.net/pcre/pcre-8.34.tar.gz
+  - url: https://sourceforge.net/projects/pcre/files/pcre/8.34/pcre-8.34.tar.bz2
     key: tar.bz2:wycdvyp7e4ql4zs77iunyivxyy343xuw
 
 build_stages:


### PR DESCRIPTION
Wrong file type and a non-permanent URL.  Fixing both.
