### PR TITLE
Explicitly build all CMake based packages with FPIC support enabled.

### DIFF
--- a/base/cmake_package.py
+++ b/base/cmake_package.py
@@ -24,6 +24,7 @@ def configure(ctx, stage_args):
     If build_in_source is set, build directory will be the same as source directory.
     """
     conf_lines = ['${CMAKE} -DCMAKE_INSTALL_PREFIX:PATH="${ARTIFACT}"',
+                  '-DCMAKE_POSITION_INDEPENDENT_CODE:BOOL=ON',
                   '-DCMAKE_INSTALL_RPATH:STRING="${ARTIFACT}/lib"',
                   '-DCMAKE_INSTALL_RPATH_USE_LINK_PATH:BOOL=ON']
 


### PR DESCRIPTION
By enabling FPIC this way we handle compilers like XLC which use non
standard flags to enable FPICiness.
