### PR TITLE
ENH: autotools/configure handling w/ env append

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: python
 env:
+  - TEST_PROFILE="test.autotools.yaml"
   - TEST_PROFILE="test.boost.yaml"
   - TEST_PROFILE="test.clawpack.gitsubmodules.yaml"
   - TEST_PROFILE="test.cmake.yaml"

--- a/pkgs/python/python.yaml
+++ b/pkgs/python/python.yaml
@@ -12,7 +12,8 @@ build_stages:
   - when: link == 'shared'
     name: configure
     mode: override
-    extra: ['--enable-shared', 'LDFLAGS=-Wl,-rpath=${ARTIFACT}/lib']
+    append: {LDFLAGS: "-Wl,-rpath=${ARTIFACT}/lib"}
+    extra: ['--enable-shared']
 
 # Make sure extension modules were built correctly. This should be part of the
 # Python buildsystem, but unfortunately currently it will silently succeed even

--- a/pkgs/test_autotools/configure
+++ b/pkgs/test_autotools/configure
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+# Fake configure script that simply writes all
+# command line arguments to configure_in.txt
+
+echo "$@" > configure_in.txt

--- a/pkgs/test_autotools/test_autotools.yaml
+++ b/pkgs/test_autotools/test_autotools.yaml
@@ -1,0 +1,39 @@
+extends: [autotools_package]
+dependencies:
+  build: [test_empty]
+
+build_stages:
+  - name: create_configure_script
+    before: configure
+    files: [configure]
+    handler: bash
+    bash: |
+      cp _hashdist/configure configure
+      chmod +x configure
+
+  - name: configure
+    extra: [--enable-shared]
+    append: {LDFLAGS: "-Wl,-rpath=${ARTIFACT}/lib"}
+
+  - name: inspect_build_script
+    handler: bash
+    bash: |
+      cat _hashdist/build.sh
+
+  - name: inspect_configure_input
+    after: configure
+    handler: bash
+    bash: |
+      cat configure_in.txt
+
+  - name: verify_configure_input
+    after: configure
+    handler: bash
+    bash: |
+      grep 'export LDFLAGS="-L${TEST_EMPTY_DIR}/lib -Wl,-rpath=${TEST_EMPTY_DIR}/lib -Wl,-rpath=${ARTIFACT}/lib"' _hashdist/build.sh
+
+  - name: make
+    mode: remove
+
+  - name: install
+    mode: remove

--- a/pkgs/test_empty.yaml
+++ b/pkgs/test_empty.yaml
@@ -1,0 +1,1 @@
+extends: [base_package]

--- a/tests/test.autotools.yaml
+++ b/tests/test.autotools.yaml
@@ -1,0 +1,5 @@
+extends:
+- file: linux.yaml
+
+packages:
+  test_autotools:


### PR DESCRIPTION
Add the ability to append to environment variables in the configure
stage.  This is especially important if the user needs to adjust CPFLAGS
or LDFLAGS, which would normally be overridden if specified in the
configure line.

This also adds two in-hashstack test packages.  These should eventually
be moved into a different directory, perhaps test/pkgs.
