### PR TITLE
Prepend PKG_CONFIG_PATH in when_build_dependency.

### DIFF
--- a/pkgs/busybee.yaml
+++ b/pkgs/busybee.yaml
@@ -20,5 +20,8 @@ build_stages:
     aclocal
     autoheader
     automake --force-missing --add-missing
-    export PKG_CONFIG_PATH="$LIBPO6_DIR/lib/pkgconfig:$LIBE_DIR/lib/pkgconfig"
     autoconf
+
+when_build_dependency:
+  - prepend_path: PKG_CONFIG_PATH
+    value: '${ARTIFACT}/lib/pkgconfig'

--- a/pkgs/freetype.yaml
+++ b/pkgs/freetype.yaml
@@ -16,3 +16,5 @@ build_stages:
 when_build_dependency:
   - prepend_path: PATH
     value: '${ARTIFACT}/bin'
+  - prepend_path: PKG_CONFIG_PATH
+    value: '${ARTIFACT}/lib/pkgconfig'

--- a/pkgs/hyperdex.yaml
+++ b/pkgs/hyperdex.yaml
@@ -33,10 +33,13 @@ build_stages:
     autoheader
     automake --force-missing --add-missing
     autoconf || true
-    export PKG_CONFIG_PATH="$LIBPO6_DIR/lib/pkgconfig:$LIBE_DIR/lib/pkgconfig:$BUSYBEE_DIR/lib/pkgconfig:$HYPERLEVELDB_DIR/lib/pkgconfig:$REPLICANT_DIR/lib/pkgconfig:$PYTHON_DIR/lib/pkgconfig"
 
 - name: configure
   extra: [
     '--enable-python-bindings',
     'LDFLAGS="-lm"',
   ]
+
+when_build_dependency:
+  - prepend_path: PKG_CONFIG_PATH
+    value: '${ARTIFACT}/lib/pkgconfig'

--- a/pkgs/hyperleveldb.yaml
+++ b/pkgs/hyperleveldb.yaml
@@ -18,3 +18,7 @@ build_stages:
     autoheader
     automake --force-missing --add-missing
     autoconf
+
+when_build_dependency:
+  - prepend_path: PKG_CONFIG_PATH
+    value: '${ARTIFACT}/lib/pkgconfig'

--- a/pkgs/libe.yaml
+++ b/pkgs/libe.yaml
@@ -17,5 +17,8 @@ build_stages:
     aclocal
     autoheader
     automake --force-missing --add-missing
-    export PKG_CONFIG_PATH="$LIBPO6_DIR/lib/pkgconfig"
     autoconf || true
+
+when_build_dependency:
+  - prepend_path: PKG_CONFIG_PATH
+    value: '${ARTIFACT}/lib/pkgconfig'

--- a/pkgs/libpo6.yaml
+++ b/pkgs/libpo6.yaml
@@ -17,3 +17,7 @@ build_stages:
     aclocal
     automake --force-missing --add-missing
     autoconf || true
+
+when_build_dependency:
+  - prepend_path: PKG_CONFIG_PATH
+    value: '${ARTIFACT}/lib/pkgconfig'

--- a/pkgs/matplotlib/matplotlib.yaml
+++ b/pkgs/matplotlib/matplotlib.yaml
@@ -9,13 +9,6 @@ sources:
 
 build_stages:
 
-- name: png_freetype_fix
-  before: install
-  handler: bash
-  bash: |
-    export PKG_CONFIG_PATH="$PNG_DIR/lib/pkgconfig:$FREETYPE_DIR/lib/pkgconfig"
-
-
 # This patch did not go into v1.3.1 :(
 - when: platform == 'Cygwin'
   name: fix_cxx_reserved_identifiers

--- a/pkgs/png.yaml
+++ b/pkgs/png.yaml
@@ -6,3 +6,7 @@ dependencies:
 sources:
 - url: http://sourceforge.net/projects/libpng/files/libpng16/older-releases/1.6.6/libpng-1.6.6.tar.gz
   key: tar.gz:dj4va2fjpzsuvcl3usxe76jiywh6phjz
+
+when_build_dependency:
+  - prepend_path: PKG_CONFIG_PATH
+    value: '${ARTIFACT}/lib/pkgconfig'

--- a/pkgs/python/python.yaml
+++ b/pkgs/python/python.yaml
@@ -61,6 +61,8 @@ when_build_dependency:
     value: ${ARTIFACT}/bin/python
   - prepend_path: PATH
     value: '${ARTIFACT}/bin'
+  - prepend_path: PKG_CONFIG_PATH
+    value: '${ARTIFACT}/lib/pkgconfig'
 
 profile_links:
   - name: python_binaries

--- a/pkgs/replicant.yaml
+++ b/pkgs/replicant.yaml
@@ -28,5 +28,8 @@ build_stages:
     aclocal
     autoheader
     automake --force-missing --add-missing
-    export PKG_CONFIG_PATH="$LIBPO6_DIR/lib/pkgconfig:$LIBE_DIR/lib/pkgconfig:$BUSYBEE_DIR/lib/pkgconfig:$HYPERLEVELDB_DIR/lib/pkgconfig"
     autoconf
+
+when_build_dependency:
+  - prepend_path: PKG_CONFIG_PATH
+    value: '${ARTIFACT}/lib/pkgconfig'


### PR DESCRIPTION
This helps avoiding accidents where we accidentally use
a system package despite specifying a local package.

It seems to me that we always want to prefer the pkg-config of hashdist packages over system packages. Would it make sense to add a `base/pkgconfig.yaml` for all packages that use pkg-config? Maybe even auto-detect this in autotools_package? Or just generally export PKG_CONFIG_PATH?
