### PR TITLE
Update to CMake 2.8.12.2 as 2.8.12.1 has some serious issues.

### DIFF
--- a/pkgs/cmake.yaml
+++ b/pkgs/cmake.yaml
@@ -1,8 +1,8 @@
 extends: [autotools_package]
 
 sources:
-- url: http://www.cmake.org/files/v2.8/cmake-2.8.12.1.tar.gz
-  key: tar.gz:7iumcj4r2zgdnotlnsygfjfuxvbcgbj7
+- url: http://www.cmake.org/files/v2.8/cmake-2.8.12.2.tar.gz
+  key: tar.gz:rrsxj2npvpfz7rtpiy53d4xqkgky3bwi
 
 when_build_dependency:
 - set: CMAKE


### PR DESCRIPTION
CMake 2.8.12.2 introduced support for XCode 5.1 which allows support
for Mavericks, also it fixed a bug when a projects minimum required
version was 2.8.12.
