### PR TITLE
Add $ARTIFACT/bin to PATH when building against PETSc

### DIFF
--- a/pkgs/petsc/petsc.yaml
+++ b/pkgs/petsc/petsc.yaml
@@ -68,3 +68,7 @@ build_stages:
   bash: |
     install $PETSC_ARCH/cyg*.dll $ARTIFACT/bin
     install $PETSC_ARCH/lib/cyg*.dll $ARTIFACT/bin
+
+when_build_dependency:
+- when platform == 'Cygwin':
+  - {prepend_path: PATH, value: '${ARTIFACT}/bin'}


### PR DESCRIPTION
This is needed when building DOLFIN.
