### PR TITLE
[WIP] Add Piranha package

### DIFF
--- a/pkgs/piranha.yaml
+++ b/pkgs/piranha.yaml
@@ -1,0 +1,17 @@
+extends: [cmake_package]
+dependencies:
+  build: [boost, gmp, mpfr]
+  run: [boost, gmp, mpfr]
+
+sources:
+- url: https://github.com/bluescarni/piranha.git
+  key: git:5887526cae6409faa09481bd84c384ec55f6ba19
+
+build_stages:
+- name: configure
+  extra: ['-D BOOST_ROOT=$BOOST_DIR',
+          '-D GMP_INCLUDE_DIR=$GMP_DIR/include',
+          '-D GMP_LIBRARIES=$GMP_DIR/lib/libgmp.so',
+          '-D MPFR_INCLUDE_DIR=$MPFR_DIR/include',
+          '-D MPFR_LIBRARIES=$MPFR_DIR/lib/libmpfr.so',
+          ]


### PR DESCRIPTION
It builds fine, but fails to install with:

```
...
[piranha] [100%] Built target rectangular_perf
[piranha] Linking CXX executable pearce2_perf
[piranha] [100%] Built target pearce2_perf
[piranha] make: *** No rule to make target `install'.  Stop.
[piranha ERROR] Command '[u'/bin/bash', '_hashdist/build.sh']' returned non-zero exit status 2
[piranha ERROR] command failed (code=2); raising
```

I have reported the issue upstream: https://github.com/bluescarni/piranha/issues/3

/cc @bluescarni
