### PR TITLE
dftatom: install Python wrappers into $ARTIFACT

### DIFF
--- a/pkgs/dftatom.yaml
+++ b/pkgs/dftatom.yaml
@@ -10,7 +10,7 @@ sources:
 build_stages:
 - name: configure
   extra: ['-D WITH_PYTHON:BOOL=ON',
-          '-D PYTHON_INSTALL_PATH:PATH=$ARTIFACT/lib/python2.7/site-packages']
+          '-D PYTHON_INSTALL_PATH:PATH=$ARTIFACT/{{python_site_packages_rel}}']
   build_in_source: true
 
 - name: setup_builddir


### PR DESCRIPTION
Instead of the Python package itself. Fixes #254
