### PR TITLE
Update ansible to a recent devel version as proxy support is now fixed, ...

### DIFF
--- a/pkgs/ansible.yaml
+++ b/pkgs/ansible.yaml
@@ -5,4 +5,4 @@ dependencies:
 
 sources:
   - url: https://github.com/ansible/ansible.git
-    key: git:ab5500072b2ec802aa8087fafc66d837de0238f9
+    key: git:33053615a7af835d713d4cc5b5fabb1c0b2b735d


### PR DESCRIPTION
...the previous removal of pyurl had broken a number of things
