### PR TITLE
Add statsmodels package + dependencies.

### DIFF
--- a/pkgs/cvxopt.yaml
+++ b/pkgs/cvxopt.yaml
@@ -1,0 +1,11 @@
+extends: [setuptools_package]
+
+dependencies:
+  build: []
+  run: []
+
+sources:
+ - url: https://pypi.python.org/packages/source/c/cvxopt/cvxopt-1.1.6.tar.gz
+   key: tar.gz:d2kamzsqxas6py3nk2xicu2vimabz74g
+
+licenses: [gplv3]

--- a/pkgs/patsy.yaml
+++ b/pkgs/patsy.yaml
@@ -1,0 +1,11 @@
+extends: [setuptools_package]
+
+dependencies:
+  build: []
+  run: []
+
+sources:
+ - url: https://pypi.python.org/packages/source/p/patsy/patsy-0.2.1.zip
+   key: zip:rfnrtchk4nwvolhq4h2djssny5zfix6w
+
+licenses: [bsd-2-clause]

--- a/pkgs/statsmodels.yaml
+++ b/pkgs/statsmodels.yaml
@@ -1,0 +1,24 @@
+extends: [setuptools_package]
+
+dependencies:
+  build:
+    - numpy
+    - scipy
+    - cvxopt
+    - patsy
+    - pandas
+    - cython
+    - python-dateutil
+  run:
+    - numpy
+    - scipy
+    - cvxopt
+    - patsy
+    - pandas
+    - python-dateutil
+
+sources:
+ - url: https://pypi.python.org/packages/source/s/statsmodels/statsmodels-0.5.0.zip
+   key: zip:a5wvmk2kguemavjoqksqzjt2z6betxxe
+
+licenses: [bsd-3-clause]


### PR DESCRIPTION
I've moved to a "slug" style for licenses. I don't really want to enforce anything just now because there's a long list of non-standard licenses. Maybe custom licenses like matplotlib need special syntax like "custom:matplotlib" but adding an embedded DSL in licence fields seems like a bad idea, too.
