### PR TITLE
Add pkg-config dependency to matplotlib

### DIFF
--- a/pkgs/matplotlib/matplotlib.yaml
+++ b/pkgs/matplotlib/matplotlib.yaml
@@ -1,6 +1,6 @@
 extends: [namespace_package, libflags]
 dependencies:
-  build: [freetype, numpy, png]
+  build: [freetype, numpy, png, pkg-config]
   run: [freetype, numpy, png, python-dateutil, pyparsing]
 
 sources:


### PR DESCRIPTION
matplotlib uses pkg-config to detect dependencies (freetype).
