### PR TITLE
Update ansible package to use a release tarball instead of a git checkou...

### DIFF
--- a/pkgs/ansible.yaml
+++ b/pkgs/ansible.yaml
@@ -1,8 +1,9 @@
 extends: [setuptools_package]
+
 dependencies:
   build: [paramiko, jinja2, yaml]
   run: [paramiko, jinja2, yaml]
 
 sources:
-  - url: https://github.com/ansible/ansible.git
-    key: git:dffea7f8770e40e73880e07689232cecdac0126a
+ - url: https://pypi.python.org/packages/source/a/ansible/ansible-1.6.3.tar.gz
+   key: tar.gz:ckansmlu3untt5zmombkg3c6okgj4uw5


### PR DESCRIPTION
...t

updating this package as proposed in another ticket/PR. This change makes the ansible package use a release tarball instead of a git checkout.
