### PR TITLE
Initial add of quilt for patch management

### DIFF
--- a/pkgs/gnu-sed.yaml
+++ b/pkgs/gnu-sed.yaml
@@ -1,0 +1,5 @@
+extends: [autotools_package]
+
+sources:
+- url: http://ftp.gnu.org/gnu/sed/sed-4.2.tar.bz2
+  key: tar.bz2:5z3vly5laohh33woxx2e7vb22znjncij

--- a/pkgs/quilt.yaml
+++ b/pkgs/quilt.yaml
@@ -1,0 +1,18 @@
+extends: [autotools_package]
+dependencies:
+  build: [gnu-sed]
+  run: [gnu-sed]
+
+sources:
+- url: http://download.savannah.gnu.org/releases/quilt/quilt-0.63.tar.gz
+  key: tar.gz:fbdhrarbvkeejrkpcarzy7f4l2eaggcz
+
+build_stages:
+
+- name: configure
+  handler: bash
+  bash: |
+    ./configure \
+      --prefix=$ARTIFACT \
+      --with-sed=$GNU_SED_DIR/bin/sed \
+      --without-getopt


### PR DESCRIPTION
For generic patch management, it is VCS agnostic

This seems to work on my machine, but I am not too confident that quilt is really picking up the correct version of sed.

I'd merge this one with caution and testing.
