### PR TITLE
Initial add of git 2.0

### DIFF
--- a/pkgs/expat.yaml
+++ b/pkgs/expat.yaml
@@ -1,0 +1,5 @@
+extends: [autotools_package]
+
+sources:
+- url: http://downloads.sourceforge.net/project/expat/expat/2.1.0/expat-2.1.0.tar.gz
+  key: tar.gz:qi3qkrzpqfw7ehepnkqcnxiwfmuaqbud

--- a/pkgs/git.yaml
+++ b/pkgs/git.yaml
@@ -1,0 +1,22 @@
+extends: [base_package]
+
+dependencies:
+  build: [curl, pcre, openssl, libiconv, expat]
+
+sources:
+- url: http://www.kernel.org/pub/software/scm/git/git-2.0.0.tar.gz
+  key: tar.gz:y2rxb2ktezyban674mxy4zxtttosqvl4
+
+build_stages:
+
+- name: make
+  after: prologue
+  handler: bash
+  bash: |
+    make prefix=${ARTIFACT}
+
+- name: install
+  after: make
+  handler: bash
+  bash: |
+    make install prefix=${ARTIFACT}


### PR DESCRIPTION
This means users can have a 'recent' version of git everywhere for convenience. Added this as mercurial is there as well in hashstack.
