### PR TITLE
Disable gettext in git build for now

### DIFF
--- a/pkgs/git.yaml
+++ b/pkgs/git.yaml
@@ -13,6 +13,7 @@ build_stages:
   after: prologue
   handler: bash
   bash: |
+    export NO_GETTEXT=1
     make prefix=${ARTIFACT}
 
 - name: install


### PR DESCRIPTION
gettext isn't needed for git to be functional. gettext is a nice to have for git. The gettext dependency is more of a problem on osx than it is on linux.
