### PR TITLE
Hashdist inside Hashdist

### DIFF
--- a/pkgs/hashdist.yaml
+++ b/pkgs/hashdist.yaml
@@ -1,5 +1,8 @@
 extends: [distutils_package]
 
+dependencies:
+   run: [git, mercurial, pyliblzma]
+
 sources:
  - url: https://github.com/hashdist/hashdist.git
    key: git:62f7b05ffe4b8c26ef744b2c1bf0fddbeb632ce0


### PR DESCRIPTION
This probably a novelty package for now, it will be useful once hashdist supports relocatable packages. It hashdist inside hashdist does work. I have been using it on an old debian squeeze system for testing/development.
