### PR TITLE
Update curl to depend on openssl and also update package to latest versi...

### DIFF
--- a/pkgs/curl.yaml
+++ b/pkgs/curl.yaml
@@ -1,5 +1,8 @@
 extends: [autotools_package]
 
+dependencies:
+    build: [openssl]
+
 sources:
-  - url: http://curl.haxx.se/download/curl-7.33.0.tar.gz
+  - url: http://curl.haxx.se/download/curl-7.37.0.tar.gz
     key: tar.gz:oriktrzl2j65rhogtfvovwxtkt5etpb4


### PR DESCRIPTION
...on

this PR basically enables ssl, and thus allows things like git to use https (via lib curl)
