### PR TITLE
Fix the curl hash, hashdist doesn't 'error' when the URL changes.

### DIFF
--- a/pkgs/curl.yaml
+++ b/pkgs/curl.yaml
@@ -5,4 +5,4 @@ dependencies:
 
 sources:
   - url: http://curl.haxx.se/download/curl-7.37.0.tar.gz
-    key: tar.gz:oriktrzl2j65rhogtfvovwxtkt5etpb4
+    key: tar.gz:dl6tespqw6zufuqodtfmxpasggdziyrs


### PR DESCRIPTION
Relates to https://github.com/hashdist/hashstack/pull/315/files#r14058576 where the hash did not get updated.
