### PR TITLE
Depend on gettext as well

### DIFF
--- a/pkgs/git.yaml
+++ b/pkgs/git.yaml
@@ -1,7 +1,7 @@
 extends: [autotools_package]
 
 dependencies:
-  build: [curl, pcre, openssl, libiconv, expat, zlib]
+  build: [curl, pcre, openssl, libiconv, gettext, expat, zlib]
 
 sources:
 - url: http://www.kernel.org/pub/software/scm/git/git-2.0.0.tar.gz


### PR DESCRIPTION
since gettext is pretty much going to be around so depend on it.

update - do not merge this. there seems to be some git build fun with default paths, the build doesn't find the msgfmt command (which is part of gettext)
