### PR TITLE
Add $ARTIFACT/bin to PATH when build dependency

### DIFF
--- a/pkgs/bison.yaml
+++ b/pkgs/bison.yaml
@@ -3,3 +3,7 @@ extends: [autotools_package]
 sources:
   - url: http://ftp.gnu.org/gnu/bison/bison-3.0.tar.gz
     key: tar.gz:4w36y5oqxgrgkxmndbkmjithrgrxbw4h
+
+when_build_dependency:
+  - prepend_path: PATH
+    value: '${ARTIFACT}/bin'

--- a/pkgs/git.yaml
+++ b/pkgs/git.yaml
@@ -12,3 +12,7 @@ build_stages:
 - name: configure
   mode: override
   extra: ['--with-libpcre=${PCRE_DIR}', '--with-zlib=${ZLIB_DIR}', '--with-iconv=${LIBICONV_DIR}', '--with-expat=${EXPAT_DIR}', '--with-curl=${CURL_DIR}']
+
+when_build_dependency:
+- prepend_path: PATH
+  value: '${ARTIFACT}/bin'

--- a/pkgs/mercurial.yaml
+++ b/pkgs/mercurial.yaml
@@ -3,3 +3,7 @@ extends: [distutils_package]
 sources:
   - url: http://mercurial.selenic.com/release/mercurial-2.9.1.tar.gz
     key: tar.gz:uih3cq2ozpnqodxzkxd4few3t2zgo274
+
+when_build_dependency:
+  - prepend_path: PATH
+    value: '${ARTIFACT}/bin'


### PR DESCRIPTION
E.g. Needed for golang to checkout godoc
