### PR TITLE
Depend on m4, bison needs m4 to build

### DIFF
--- a/pkgs/bison.yaml
+++ b/pkgs/bison.yaml
@@ -1,5 +1,8 @@
 extends: [autotools_package]
 
+dependencies:
+  build: [m4]
+
 sources:
   - url: http://ftp.gnu.org/gnu/bison/bison-3.0.tar.gz
     key: tar.gz:4w36y5oqxgrgkxmndbkmjithrgrxbw4h


### PR DESCRIPTION
Discussed in https://github.com/hashdist/hashstack/issues/321, adding m4 as a dependency. This is useful for fresh systems without much.
