### PR TITLE
Apply patch to libiconv only on linux where modern versions of glibc cau...

### DIFF
--- a/pkgs/libiconv-bootstrap/libiconv-bootstrap.yaml
+++ b/pkgs/libiconv-bootstrap/libiconv-bootstrap.yaml
@@ -5,7 +5,8 @@ sources:
     key: tar.gz:okze33ix22drspbtm3ioxz6n4htlddyn
 
 build_stages:
-  - name: patch
+  - when: platform == 'linux'
+    name: patch
     before: configure
     files: [modern-glibc-workaround.patch]
     handler: bash

--- a/pkgs/libiconv/libiconv.yaml
+++ b/pkgs/libiconv/libiconv.yaml
@@ -8,7 +8,8 @@ sources:
     key: tar.gz:okze33ix22drspbtm3ioxz6n4htlddyn
 
 build_stages:
-  - name: patch
+  - when: platform == 'linux'
+    name: patch
     before: configure
     files: [modern-glibc-workaround.patch]
     handler: bash


### PR DESCRIPTION
...ses build issues

The patch that currently exists in the libiconv patches only work on linux based systems where glibc exist. The current package fails on OSX, this PR fixes the problem.
