### PR TITLE
Revert "Sphinx should be a distutils package"

### DIFF
--- a/pkgs/sphinx.yaml
+++ b/pkgs/sphinx.yaml
@@ -1,4 +1,4 @@
-extends: [distutils_package]
+extends: [setuptools_package]
 dependencies:
   build: [docutils, jinja2, pygments]
   run: [jinja2, pygments]


### PR DESCRIPTION
Fixes #327.

This reverts commit 9bf384a00c14976498745939d4065d9b291b871d.

@ahmadia, I cannot find the PR, which introduced the 9bf384a00c14976498745939d4065d9b291b871d commit, but in there you write that it breaks some profiles. Can you specify exactly what gets broken? We need to fix the root of the problem. Your fix breaks sphinx, because now it downloads setuptools from the internet during build, which is a big no no.
