### PR TITLE
Tweak openssl package to deal with not being 64bit on OSX

### DIFF
--- a/pkgs/openssl/openssl.yaml
+++ b/pkgs/openssl/openssl.yaml
@@ -27,3 +27,12 @@ build_stages:
   bash: |
     #./config --prefix=$ARTIFACT shared zlib-dynamic -I$ZLIB_DIR/include -Wl,-rpath=$ARTIFACT/lib -Wl,-rpath=$ZLIB_DIR/lib
     ./config --prefix=$ARTIFACT shared zlib-dynamic -I$ZLIB_DIR/include
+
+- when: platform == 'Darwin'
+  name: configure
+  after: fix_docs
+  handler: bash
+  mode: replace
+  bash: |
+    #./config --prefix=$ARTIFACT shared zlib-dynamic -I$ZLIB_DIR/include -Wl,-rpath=$ARTIFACT/lib -Wl,-rpath=$ZLIB_DIR/lib
+    ./Configure --prefix=$ARTIFACT shared zlib-dynamic -I$ZLIB_DIR/include darwin64-x86_64-cc enable-ec_nistp-64_gcc_128


### PR DESCRIPTION
This only enforces the 64bit builds of openssl on OSX, to build 32bit builds just remove 'darwin64-x86_64-cc enable-ec_nistp-64_gcc_128' We assume most if not all people have a 64bit processor
