### PR TITLE
flex build depends on m4

### DIFF
--- a/pkgs/flex.yaml
+++ b/pkgs/flex.yaml
@@ -1,5 +1,8 @@
 extends: [autotools_package]
 
+dependencies:
+  build: [m4]
+
 sources:
 - url: http://downloads.sourceforge.net/project/flex/flex-2.5.39.tar.bz2
   key: tar.bz2:vxjlkxz3yoglkevur6wx24xuhmi66jce


### PR DESCRIPTION
This is similar to the bison package where it needs m4
