### PR TITLE
Default example should use host-lapack

### DIFF
--- a/default.example.yaml
+++ b/default.example.yaml
@@ -42,6 +42,8 @@ packages:
     use: host-mpi
   blas:
     use: host-blas
+  lapack:
+    use: host-lapack
 
   nose:
   hdf5:
@@ -56,6 +58,3 @@ packages:
     with_conf: true
   szip:
   zlib:
-
-
-


### PR DESCRIPTION
Be more verbose in this example. If a use has lapack installed chances
are blas will be installed as well, but not vice versa.
