### PR TITLE
Launcher should not extend from base_package

### DIFF
--- a/pkgs/launcher.yaml
+++ b/pkgs/launcher.yaml
@@ -1,3 +1,5 @@
+# Note: do not inherit from base_package.yaml
+# Symlinking the launcher interferes with its operation
 
 sources:
   - url: https://github.com/hashdist/hdist-launcher.git


### PR DESCRIPTION
I'm not sure when this happened, but launcher should not do this.

It looks like we added the extend when implementing
the Garnet port, so this commit may break hashstack on Crays.
