### PR TITLE
Fix M2Crypto to use hashdist openssl

### DIFF
--- a/pkgs/M2Crypto.yaml
+++ b/pkgs/M2Crypto.yaml
@@ -7,3 +7,14 @@ dependencies:
 sources:
  - url: https://pypi.python.org/packages/source/M/M2Crypto/M2Crypto-0.22.3.tar.gz
    key: tar.gz:mby37sax3fdsh2nulcqbbvlfgziqj6ck
+
+build_stages:
+
+- name: install
+  after: setup_dirs
+  handler: bash
+  bash: |
+    # build
+    $PYTHON setup.py build build_ext --openssl=${OPENSSL_DIR}
+    # install
+    $PYTHON setup.py install --prefix=${ARTIFACT}


### PR DESCRIPTION
M2Crypto wasn't linking against openssl provided by hashdist, this patch fixes the build to do so. It relates to https://github.com/jcftang/hashstack2/commit/50216bf92e0bc23e800553ceb1863b28c896a1b9
