### PR TITLE
ruby: try to require some modules

### DIFF
--- a/pkgs/ruby.yaml
+++ b/pkgs/ruby.yaml
@@ -14,3 +14,20 @@ defaults:
 profile_links:
   - name: gem_binaries
     link: 'lib/ruby/gems/2.1.0/**/bin/*'
+
+build_stages:
+  - name: test_modules
+    after: install
+    handler: bash
+    bash: |
+      echo "require 'digest'"
+      $ARTIFACT/bin/ruby -e "require 'digest'"
+      echo "    ok"
+
+      echo "require 'openssl'"
+      $ARTIFACT/bin/ruby -e "require 'openssl'"
+      echo "    ok"
+
+      echo "require 'yaml'"
+      $ARTIFACT/bin/ruby -e "require 'yaml'"
+      echo "    ok"


### PR DESCRIPTION
Similar to the current python package, try to require some of the
ruby modules such as openssl to make sure things are really compiled
correctly. The tests is currently very limited and may be expanded
at a later date.
