### PR TITLE
mpich: disable fortran support on osx.

### DIFF
--- a/pkgs/mpich.yaml
+++ b/pkgs/mpich.yaml
@@ -3,8 +3,9 @@ extends: [autotools_package]
 build_stages:
   - name: configure
     mode: override
-    extra: ['--enable-shared']
-
+    extra:
+      - '--enable-shared'
+      - when platform == "Darwin": ['--disable-f77','--disable-fc']
 
 sources:
   - url: http://www.mpich.org/static/tarballs/3.0.3/mpich-3.0.3.tar.gz


### PR DESCRIPTION
Since Xcode does not have support for fortran, I propose that we do not build mpich with fortran support on OSX. We can then use ``mpi: use mpich`` to satisfy the mpi dependency of packages such as boost, which currently does not build on osx.