### PR TITLE
Update QT to 4.8.6

### DIFF
--- a/pkgs/qt/qt.yaml
+++ b/pkgs/qt/qt.yaml
@@ -6,6 +6,11 @@ sources:
 - key: tar.gz:rmkn3envfbrobg4onkldkb5xjpbfqb4h
   url: http://download.qt-project.org/archive/qt/4.8/4.8.6/qt-everywhere-opensource-src-4.8.6.tar.gz
 
+defaults:
+  # bin/qmake contains hard-coded path
+  relocatable: false
+
+
 #on the mac we need to pass the sdk and arch down
 build_stages:
 - name: configure


### PR DESCRIPTION
The current version can't be downloaded any more:

```
Downloading http://download.qt-project.org/official_releases/qt/4.8/4.8.5/qt-everywhere-opensource-src-4.8.5.tar.gz...
[ERROR] urllib failed to download (code: 404): http://download.qt-project.org/official_releases/qt/4.8/4.8.5/qt-everywhere-opensource-src-4.8.5.tar.gz
```

And the new version 5.3.1 doesn't compile with the current build script.
