### PR TITLE
Let users specify the builddir for cmake

### DIFF
--- a/base/cmake_package.py
+++ b/base/cmake_package.py
@@ -51,7 +51,7 @@ def configure(ctx, stage_args):
     if 'extra' in stage_args:
         conf_lines.append(' '.join('%s' % arg for arg in stage_args['extra']))
 
-    builddir = '..'
+    builddir = stage_args.get('builddir', '..')
     if stage_args.get('build_in_source', False):
         builddir = '.'
     conf_lines.append(builddir)


### PR DESCRIPTION
This change lets users specify 'builddir' This is to enable
applications/libraries such as https://github.com/EttusResearch/uhd to
be built where the CMakeLists file isn't in the top level directory.
