### PR TITLE
Paraview: add bzip2 as an explicit dependency

### DIFF
--- a/pkgs/paraview/paraview.yaml
+++ b/pkgs/paraview/paraview.yaml
@@ -1,6 +1,6 @@
 extends: [cmake_package]
 dependencies:
-  build: [boost, png, qt, zlib, gdal, hdf5,
+  build: [boost, png, qt, zlib, bzip2, gdal, hdf5,
           mpi, netcdf4, netcdf4cpp, freetype,
           python, numpy, matplotlib, libxml2, {{build_with}}]
 


### PR DESCRIPTION
Fixes #395, because it adds the proper RPATHs into the build, so that the
proper bzip2 is found during the build.
