### PR TITLE
Configure PETSc without F77, F90 and FC on Darwin

### DIFF
--- a/examples/proteus.Darwin.yaml
+++ b/examples/proteus.Darwin.yaml
@@ -8,6 +8,9 @@
 extends:
 - file: osx.yaml
 
+parameters:
+  fortran: true
+
 # The packages list specifies all the packages that you 
 # require installed.  <#> will ensure that all packages
 # and their dependencies are installed when you build this

--- a/linux.yaml
+++ b/linux.yaml
@@ -3,4 +3,5 @@ extends:
 
 parameters:
   platform: linux
+  fortran: true
   PATH: /usr/bin:/bin

--- a/osx.yaml
+++ b/osx.yaml
@@ -3,6 +3,7 @@ extends:
 
 parameters:
   platform: Darwin
+  fortran: false
   PATH: /usr/bin:/bin:/usr/sbin:/sbin:/usr/local/bin
   PROLOGUE: |
     export MACOSX_DEPLOYMENT_TARGET=$(sw_vers -productVersion | sed "s/\(10.[0-9]\).*/\1/")

--- a/pkgs/petsc/petsc.py
+++ b/pkgs/petsc/petsc.py
@@ -118,7 +118,7 @@ def configure(ctx, stage_args):
             conf_lines.append('--with-mpi-compilers')
             conf_lines.append('CC=$MPICC')
             conf_lines.append('CXX=$MPICXX')
-            if ctx.parameters['platform'] != 'Darwin':
+            if ctx.parameters['fortran']:
                 conf_lines.append('F77=$MPIF77')
                 conf_lines.append('F90=$MPIF90')
                 conf_lines.append('FC=$MPIF90')

--- a/pkgs/petsc/petsc.yaml
+++ b/pkgs/petsc/petsc.yaml
@@ -9,6 +9,7 @@ sources:
 defaults:
   # /include/petscconfiginfo.h contains absolute path
   relocatable: false
+  fortran: false
 
 build_stages: 
 
@@ -63,7 +64,7 @@ build_stages:
     install_name_tool -change libmetis.dylib ${PARMETIS_DIR}/lib/libmetis.dylib ${ARTIFACT}/lib/libpetsc.dylib
     install_name_tool -change libparmetis.dylib ${PARMETIS_DIR}/lib/libparmetis.dylib ${ARTIFACT}/lib/libpetsc.dylib
 
-# Special case for need to move DLLs into appropriate directories
+# Special case for Cygwin, move DLLs into appropriate directories
 - when: platform == 'Cygwin'
   name: dll_fix
   handler: bash


### PR DESCRIPTION
On Darwin there is no Fortran compiler. This PR will therefore configure PETSc without setting `F77`, `F90` and `FC` on this platform.

This fixes issue #403.
