### PR TITLE
Minor change in how rpath is set in openmpi wrapper ldflags for Darwin.

### DIFF
--- a/pkgs/openmpi.yaml
+++ b/pkgs/openmpi.yaml
@@ -10,11 +10,15 @@ defaults:
 
 build_stages:
 - name: configure
-  extra: ['--enable-mpi-thread-multiple',
-          '--enable-opal-multi-threads',
-          '--with-threads=posix',
-          '--disable-mpi-profile',
-          '--with-wrapper-ldflags=-Wl,-rpath=${ARTIFACT}/lib']
+  extra:
+    - '--enable-mpi-thread-multiple'
+    - '--enable-opal-multi-threads'
+    - '--with-threads=posix'
+    - '--disable-mpi-profile'
+    - when platform == 'linux':
+      - '--with-wrapper-ldflags=-Wl,-rpath=${ARTIFACT}/lib'
+    - when platform == 'Darwin':
+      - '--with-wrapper-ldflags=-Wl,-rpath,${ARTIFACT}/lib'
 
 when_build_dependency:
 - {set: 'MPICC', value: "${ARTIFACT}/bin/mpicc"}


### PR DESCRIPTION
`-Wl,rpath=/foo` does not work on Darwin, while `-Wl,rpath,/foo` does. This PR fixes this.
