### PR TITLE
Disable __pycache__ for Python 3 for now

### DIFF
--- a/pkgs/python/python.yaml
+++ b/pkgs/python/python.yaml
@@ -139,6 +139,9 @@ build_stages:
 when_build_dependency:
   - set: PYTHON
     value: ${ARTIFACT}/bin/python
+  - when: pyver != '2.7'
+    set: PYTHONDONTWRITEBYTECODE
+    value: 'yes'
   - prepend_path: PATH
     value: '${ARTIFACT}/bin'
   - prepend_path: PKG_CONFIG_PATH


### PR DESCRIPTION
The contents of it collides between packages at profile creation. There might
be a way to make it work with proper tweaking of the 'profile_links' section,
but for now this fixes the problem.
