### PR TITLE
Use the --without-ensurepip option with Python 3.4

### DIFF
--- a/pkgs/python/python.yaml
+++ b/pkgs/python/python.yaml
@@ -35,6 +35,8 @@ build_stages:
     when link == 'shared' and pyver == '3.4':
       append: {LDFLAGS: "-Wl,-rpath=${ARTIFACT}/lib"}
       extra: ['--enable-shared', '--without-ensurepip']
+    when link != 'shared' and pyver == '3.4':
+      extra: ['--without-ensurepip']
     when python_framework and pyver != '3.4':
       extra: ['--enable-framework=${ARTIFACT}']
     when python_framework and pyver == '3.4':


### PR DESCRIPTION
Unfortunately the yaml syntax is quite ugly, but it works for all combinations
of options.
