### PR TITLE
Fix pkg-config-wrapper to work with Python 3

### DIFF
--- a/pkgs/pkg-config/pkg-config-wrapper
+++ b/pkgs/pkg-config/pkg-config-wrapper
@@ -41,7 +41,7 @@ class PkgConfigWrapper(object):
         except CalledProcessError as err:
             log.debug('caught error: rc = %s', err.returncode)
             raise SystemExit(err.returncode)
-        output = output.rstrip()
+        output = output.rstrip().decode("utf-8")
         log.debug('intercepted: %s', output)
         return output
 


### PR DESCRIPTION
The main patch is 0aa260586fab2dab3bc40157acbac9f36e50c77f. Fixes #546.

@vbraun, you wrote the original code, could you please review this?
