### PR TITLE
M2Crypto and supervisor: make install more reliable

### DIFF
--- a/pkgs/M2Crypto.yaml
+++ b/pkgs/M2Crypto.yaml
@@ -14,6 +14,8 @@ build_stages:
   after: setup_dirs
   handler: bash
   bash: |
+    mkdir -p $ARTIFACT/lib/python2.7/site-packages
+    export PYTHONPATH=$PYTHONPATH:$ARTIFACT/lib/python2.7/site-packages
     # build
     $PYTHON setup.py build build_ext --openssl=${OPENSSL_DIR}
     # install

--- a/pkgs/supervisor.yaml
+++ b/pkgs/supervisor.yaml
@@ -1,7 +1,7 @@
-extends: [distutils_package]
+extends: [setuptools_package]
 
 dependencies:
-  build: [meld3, superlance, setuptools]
+  build: [meld3, superlance]
   run: [meld3, superlance]
 
 sources:


### PR DESCRIPTION
Now builds on osx yosemite, there was a number of build issues which are now corrected. This relates to https://github.com/hashdist/hashstack/issues/563
