### PR TITLE
berkeleydb-5: Fix for xcode 4.6 on OSX

### DIFF
--- a/pkgs/berkeleydb-5/berkeleydb-5.yaml
+++ b/pkgs/berkeleydb-5/berkeleydb-5.yaml
@@ -5,6 +5,15 @@ sources:
   url: http://download.oracle.com/berkeley-db/db-5.3.28.tar.gz
 
 build_stages:
+- name: xcode_4_6
+  when: platform == 'Darwin'
+  after: prologue
+  before: configure
+  handler: bash
+  files: [xcode_4_6.patch]
+  bash: |
+    patch -p1 < _hashdist/xcode_4_6.patch
+
 - name: configure
   after: prologue
   mode: replace

--- a/pkgs/berkeleydb-5/xcode_4_6.patch
+++ b/pkgs/berkeleydb-5/xcode_4_6.patch
@@ -1,0 +1,22 @@
+diff --git a/src/dbinc/atomic.h b/src/dbinc/atomic.h
+index 096176a..561037a 100644
+--- a/src/dbinc/atomic.h
++++ b/src/dbinc/atomic.h
+@@ -144,7 +144,7 @@ typedef LONG volatile *interlocked_val;
+ #define	atomic_inc(env, p)	__atomic_inc(p)
+ #define	atomic_dec(env, p)	__atomic_dec(p)
+ #define	atomic_compare_exchange(env, p, o, n)	\
+-	__atomic_compare_exchange((p), (o), (n))
++	__atomic_compare_exchange_db((p), (o), (n))
+ static inline int __atomic_inc(db_atomic_t *p)
+ {
+ 	int	temp;
+@@ -176,7 +176,7 @@ static inline int __atomic_dec(db_atomic_t *p)
+  * http://gcc.gnu.org/onlinedocs/gcc-4.1.0/gcc/Atomic-Builtins.html
+  * which configure could be changed to use.
+  */
+-static inline int __atomic_compare_exchange(
++static inline int __atomic_compare_exchange_db(
+ 	db_atomic_t *p, atomic_value_t oldval, atomic_value_t newval)
+ {
+ 	atomic_value_t was;


### PR DESCRIPTION
See patch in
https://raw.githubusercontent.com/Homebrew/homebrew/master/Library/Formula/berkeley-db.rb

This is a generic fix to work around a new built-in in xcode 4.6, it should not affect older versions of xcode.
