### PR TITLE
MPL: Add "six" among runtime dependencies

### DIFF
--- a/pkgs/matplotlib/matplotlib.yaml
+++ b/pkgs/matplotlib/matplotlib.yaml
@@ -1,7 +1,7 @@
 extends: [namespace_package, libflags]
 dependencies:
   build: [bzip2, freetype, numpy, png, pkg-config, zlib]
-  run: [freetype, numpy, png, python-dateutil, pyparsing]
+  run: [freetype, numpy, png, python-dateutil, pyparsing, six]
 
 sources:
 - key: tar.gz:c6r4ofkpcuwy37wr6n2rpqfiyxnwvxsp


### PR DESCRIPTION
Matplotlib depends on 'six' for Python 3. I've added it as a dependency for all Python's, if it doesn't break anything, then I would just keep it.
