### PR TITLE
Increase max dims in netcdf

### DIFF
--- a/pkgs/netcdf4/max_dims.patch
+++ b/pkgs/netcdf4/max_dims.patch
@@ -1,0 +1,24 @@
+commit c3e8003955febdb8e46c760d21fe891f958dd245
+Author: Ondřej Čertík <ondrej.certik@gmail.com>
+Date:   Sun Dec 7 23:11:01 2014 -0700
+
+    Increase max dimensions
+
+    In order to handle larger meshes in libraries like ExodusII and Moab.
+
+diff --git a/include/netcdf.h b/include/netcdf.h
+index 5d556bc..a642b71 100644
+--- a/include/netcdf.h
++++ b/include/netcdf.h
+@@ -225,9 +225,9 @@ created with the ::NC_CLASSIC_MODEL flag.
+ As a rule, NC_MAX_VAR_DIMS <= NC_MAX_DIMS.
+ */
+ /**@{*/
+-#define NC_MAX_DIMS	1024	
++#define NC_MAX_DIMS	65536
+ #define NC_MAX_ATTRS	8192	
+-#define NC_MAX_VARS	8192	
++#define NC_MAX_VARS	524288
+ #define NC_MAX_NAME	256	
+ #define NC_MAX_VAR_DIMS	1024 /**< max per variable dimensions */
+ /**@}*/

--- a/pkgs/netcdf4/netcdf4.yaml
+++ b/pkgs/netcdf4/netcdf4.yaml
@@ -6,6 +6,9 @@ sources:
 - key: tar.gz:k4egwq4dz2jdf4c2vvyhmhbkma2ldiga
   url: ftp://ftp.unidata.ucar.edu/pub/netcdf/netcdf-4.3.2.tar.gz
 
+defaults:
+  increase_max_dims: false
+
 build_stages:
 
 - name: set_mpi_wrapper
@@ -41,3 +44,11 @@ build_stages:
   before: make
   bash: |
     patch -p1 < _hashdist/hdf5-1.8.13_fix.patch
+
+- when: increase_max_dims
+  files: [max_dims.patch]
+  name: max_dims
+  handler: bash
+  before: make
+  bash: |
+    patch -p1 < _hashdist/max_dims.patch


### PR DESCRIPTION
This is needed for ExodusII. It is turned off by default, as it seems the
netcdf developers know about this issue:

http://www.unidata.ucar.edu/support/help/MailArchives/netcdf/msg09258.html

But they didn't change it by default. Here is another reference about it (https://cubit.sandia.gov/public/13.2/help_manual/WebHelp/finite_element_model/export/exporting_exodus2_file.htm):

> Note that the 'stock' ncdump utility should work for most meshes; however, Sandia increases some of the dimensions in order to handle larger meshes (more element blocks, boundary conditions, variables). The dimensions we increase in netcdf.h are:
> 
> NC_MAX_DIMS (max dimensions per file) from 100 to 65536
> NC_MAX_VARS (max variables per file) from 2000 to 524288

Use this new feature as:

```
packages:
  netcdf4:
    increase_max_dims: true
```
