### PR TITLE
Don't set LDFLAGS in scipy if we can help it

### DIFF
--- a/pkgs/scipy/scipy.yaml
+++ b/pkgs/scipy/scipy.yaml
@@ -1,4 +1,7 @@
-extends: [distutils_package, libflags]
+when platform != 'linux':
+  extends: [distutils_package]
+when platform == 'linux':
+  extends: [distutils_package, libflags]
 dependencies:
   build: [lapack, numpy]
   run: [lapack, numpy]


### PR DESCRIPTION
LDFLAGS overrides the default settings in numpy.distutils, which breaks
the OS X build in non-trivial ways.

Fixes: https://github.com/hashdist/hashstack/issues/562
