### PR TITLE
libffi: the build requires gnu-sed

### DIFF
--- a/pkgs/libffi.yaml
+++ b/pkgs/libffi.yaml
@@ -1,5 +1,8 @@
 extends: [autotools_package]
 
+dependencies:
+  build: [gnu-sed]
+
 defaults:
   relocatable: false
 


### PR DESCRIPTION
OSX ships with a bsd styled version of sed which fails when editing the
makefile
