### PR TITLE
fix MACOSX_DEPLOYMENT_TARGET for OS X > 10.9

### DIFF
--- a/darwin.yaml
+++ b/darwin.yaml
@@ -5,7 +5,7 @@ parameters:
   platform: Darwin
   PATH: /usr/bin:/bin:/usr/sbin:/sbin:/usr/local/bin
   PROLOGUE: |
-    export MACOSX_DEPLOYMENT_TARGET=$(sw_vers -productVersion | sed "s/\(10.[0-9]\).*/\1/")
+    export MACOSX_DEPLOYMENT_TARGET=$(sw_vers -productVersion | sed -E "s/([0-9]+\.[0-9]+).*/\1/")
 
 packages:
   blas:

--- a/osx.yaml
+++ b/osx.yaml
@@ -6,4 +6,4 @@ parameters:
   fortran: false
   PATH: /usr/bin:/bin:/usr/sbin:/sbin:/usr/local/bin
   PROLOGUE: |
-    export MACOSX_DEPLOYMENT_TARGET=$(sw_vers -productVersion | sed "s/\(10.[0-9]*\).*/\1/")
+    export MACOSX_DEPLOYMENT_TARGET=$(sw_vers -productVersion | sed -E "s/([0-9]+\.[0-9]+).*/\1/")


### PR DESCRIPTION
[regular expression](http://xkcd.com/1171/) only caught first digit of minor version, turning 10.10 into 10.1.

Symptom was that Cython and other Python extensions would fail to build due to Python being told it was on a super old system. Surprisingly, Python itself did not fail to build.
