### PR TITLE
Add h5py as dependency on fenicstools

### DIFF
--- a/pkgs/fenicstools.yaml
+++ b/pkgs/fenicstools.yaml
@@ -1,7 +1,7 @@
 extends: [distutils_package]
 dependencies:
   build: []
-  run: [mpi4py, numpy, python-netcdf4, pyvtk]
+  run: [mpi4py, numpy, h5py, python-netcdf4, pyvtk]
 
 sources:
 - key: git:cca3ed1cc39215636ebd3e2449dae44d5bb5781a


### PR DESCRIPTION
Missing dependency on fenicstools. It will not break the installation, but when importing it will result in

```python
>>> from fenicstools import *
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usit/abel/u1/aslakwb/nobackup/hashstack/fenics.dolfin.eps/lib/python2.7/site-packages/fenicstools/__init__.py", line 2, in <module>
    from StructuredGrid import StructuredGrid, ChannelGrid
  File "/usit/abel/u1/aslakwb/nobackup/hashstack/fenics.dolfin.eps/lib/python2.7/site-packages/fenicstools/StructuredGrid.py", line 10, in <module>
    import pyvtk, h5py, copy
ImportError: No module named h5py
```
