### PR TITLE
Upgrade OpenMPI to latest stable version 1.8.4.

### DIFF
--- a/pkgs/openmpi.yaml
+++ b/pkgs/openmpi.yaml
@@ -1,8 +1,8 @@
 extends: [autotools_package]
 
 sources:
-- url: http://www.open-mpi.org/software/ompi/v1.6/downloads/openmpi-1.6.5.tar.bz2
-  key: tar.bz2:7y33voe3l3zdjyfmqlohtaucykvqreal
+- key: tar.bz2:emky3eloslea4kjeafvxi2utse52p6xj
+  url: http://www.open-mpi.org/software/ompi/v1.8/downloads/openmpi-1.8.4.tar.bz2
 
 defaults:
   # lib/openmpi/mca_carto_auto_detect.la contains hard-coded path


### PR DESCRIPTION
The current version of OpenMPI in HashStack is old and it would be good to upgrade to the latest stable version.