### PR TITLE
Autotools update

### DIFF
--- a/pkgs/automake.yaml
+++ b/pkgs/automake.yaml
@@ -1,7 +1,7 @@
 extends: [autotools_package]
 
-#dependencies:
-#  build: [perl]
+dependencies:
+  build: [autoconf]
 
 defaults:
   relocatable: false

--- a/pkgs/automake.yaml
+++ b/pkgs/automake.yaml
@@ -7,8 +7,8 @@ defaults:
   relocatable: false
 
 sources:
-- key: tar.gz:pbduetkcatiwe7ast2obloa6crmdnl5c
-  url: http://ftp.heanet.ie/mirrors/gnu/automake/automake-1.14.tar.gz
+- key: tar.xz:teemowvl2sorgzq5nxfrxq4ceuwsftdx
+  url: http://ftp.gnu.org/gnu/automake/automake-1.15.tar.xz
 
 when_build_dependency:
 - prepend_path: PATH

--- a/pkgs/coreutils.yaml
+++ b/pkgs/coreutils.yaml
@@ -4,5 +4,5 @@ defaults:
   relocatable: false
 
 sources:
-- key: tar.gz:vkmr7jbjnmrp7eu2ggs4wvjixn4dzbgn
-  url: http://ftp.heanet.ie/mirrors/gnu/coreutils/coreutils-8.9.tar.gz
+- key: tar.xz:5rb4uw6pyyreflgli237cipww2co4ipm
+  url: http://ftp.gnu.org/gnu/coreutils/coreutils-8.23.tar.xz

--- a/pkgs/diffutils.yaml
+++ b/pkgs/diffutils.yaml
@@ -4,8 +4,8 @@ defaults:
   relocatable: false
 
 sources:
-- key: tar.gz:fkvox33blpt5ynsta2quzks5e45e7qlu
-  url: http://ftp.heanet.ie/mirrors/gnu/diffutils/diffutils-3.2.tar.gz
+- key: tar.xz:ujpitkflmx662fzr4qmgxyn3exg2sz4d
+  url: http://ftp.gnu.org/gnu/diffutils/diffutils-3.3.tar.xz
 
 when_build_dependency:
 - prepend_path: PATH


### PR DESCRIPTION
@jcftang you added the initial packages --- any reason why you added such old versions? They don't build anymore on my laptop. This PR fixes it.

The only downside that I can see is that the newest versions are only distributed as `.xz` archives (lzma), which means that `hit` with default Python can't unpack them. I had to install `python-lzma` into my Ubuntu.

I also fully uninstalled any automake/autotools packages, so that I can check that these build (i.e. I discovered the need for 801503f71f41f02e3600b49d043a4276fcfbe20f using this approach).