### PR TITLE
Fix the lzma module

### DIFF
--- a/pkgs/pyliblzma.yaml
+++ b/pkgs/pyliblzma.yaml
@@ -1,4 +1,4 @@
-extends: [setuptools_package]
+extends: [setuptools_package, libflags]
 
 dependencies:
   build: [xz]

--- a/pkgs/xz.yaml
+++ b/pkgs/xz.yaml
@@ -4,6 +4,10 @@ sources:
 - url: http://tukaani.org/xz/xz-5.0.5.tar.bz2
   key: tar.bz2:czweruueeum3yt4wgm577hrgl6gn3jcn
 
+defaults:
+  # bin/lzmainfo contains hard-coded path
+  relocatable: false
+
 when_build_dependency:
 - prepend_path: PKG_CONFIG_PATH
   value: '${ARTIFACT}/lib/pkgconfig'


### PR DESCRIPTION
This module is needed for `hit` now, as some packages are only distributed as `.xz` archives.