### PR TITLE
Build PETSc with ssl only when a dependency

### DIFF
--- a/pkgs/openssl/openssl.yaml
+++ b/pkgs/openssl/openssl.yaml
@@ -1,7 +1,7 @@
 extends: [autotools_package]
 
 dependencies:
-  build: [zlib]
+  build: [pkg-config, zlib]
 
 sources:
   - url: https://www.openssl.org/source/openssl-1.0.1g.tar.gz
@@ -46,3 +46,7 @@ build_stages:
   bash: |
     #./config --prefix=$ARTIFACT shared zlib-dynamic -I$ZLIB_DIR/include -Wl,-rpath=$ARTIFACT/lib -Wl,-rpath=$ZLIB_DIR/lib
     ./Configure --prefix=$ARTIFACT shared zlib-dynamic -I$ZLIB_DIR/include darwin64-x86_64-cc enable-ec_nistp-64_gcc_128
+
+when_build_dependency:
+- prepend_path: PKG_CONFIG_PATH
+  value: '${ARTIFACT}/lib/pkgconfig'

--- a/pkgs/petsc/petsc.py
+++ b/pkgs/petsc/petsc.py
@@ -69,6 +69,14 @@ def configure(ctx, stage_args):
     # must explicitly set --with-debugging=0 to disable debugging
     conf_lines.append('--with-debugging=%d' % stage_args['debug'])
 
+    # Special case, openssl provides ssl
+    if 'OPENSSL' in ctx.dependency_dir_vars:
+        conf_lines.append('--with-ssl=1')
+        conf_lines.append('--with-ssl-dir=${OPENSSL_DIR}')
+    else:
+        # Disable ssl when not a dependency
+        conf_lines.append('--with-ssl=0')
+
     # Special case, --with-blas-dir does not work with OpenBLAS
     if 'OPENBLAS' in ctx.dependency_dir_vars:
         if ctx.parameters['platform'] == 'Darwin':


### PR DESCRIPTION
When building `python` with HashDist it will be built with `openssl` and when building `petsc` it will by default be built with `ssl` from the system. This leads to problems like the following when building `dolfin`:

    CMake Warning at bench/fem/speedup/cpp/CMakeLists.txt:44 (add_executable):
      Cannot generate a safe runtime search path for target bench_solve-poisson
      because files in some directories may conflict with libraries in implicit
      directories:
    
        runtime library [libssl.so.1.0.0] in /usr/lib/x86_64-linux-gnu may be hidden by files in:
          /home/martinal/.hashdist/bld/profile/5c5xotjofrcc/lib
        runtime library [libcrypto.so.1.0.0] in /usr/lib/x86_64-linux-gnu may be hidden by files in:
          /home/martinal/.hashdist/bld/profile/5c5xotjofrcc/lib
    
      Some of these libraries may not be found correctly.

The problem is that `python` and `petsc` is linked with different `ssl` libraries.

This PR makes sure that `ssl` is only turned on for `petsc` when `openssl` is added as a dependency. Otherwise it is turned off.