### PR TITLE
Make gcc embed rpath automatically

### DIFF
--- a/pkgs/gcc/gcc.yaml
+++ b/pkgs/gcc/gcc.yaml
@@ -12,6 +12,19 @@ sources:
   url: http://ftpmirror.gnu.org/gcc/gcc-4.9.2/gcc-4.9.2.tar.bz2
 
 build_stages:
+  - name: rpath_patch
+    before: rpath_sed
+    files: [rpath.patch]
+    handler: bash
+    bash: |
+      patch -up1 < _hashdist/rpath.patch
+
+  - name: rpath_sed
+    before: configure
+    handler: bash
+    bash: |
+      sed -i "s|@@ARTIFACT@@|${ARTIFACT}|g" gcc/config/i386/gnu-user.h gcc/config/i386/gnu-user64.h
+
   - name: link_lib64_to_lib
     after: install
     handler: bash

--- a/pkgs/gcc/gcc.yaml
+++ b/pkgs/gcc/gcc.yaml
@@ -13,16 +13,11 @@ sources:
 
 build_stages:
   - name: rpath_patch
-    before: rpath_sed
+    before: configure
     files: [rpath.patch]
     handler: bash
     bash: |
       patch -up1 < _hashdist/rpath.patch
-
-  - name: rpath_sed
-    before: configure
-    handler: bash
-    bash: |
       sed -i "s|@@ARTIFACT@@|${ARTIFACT}|g" gcc/config/i386/gnu-user.h gcc/config/i386/gnu-user64.h
 
   - name: link_lib64_to_lib

--- a/pkgs/gcc/gcc.yaml
+++ b/pkgs/gcc/gcc.yaml
@@ -12,6 +12,8 @@ sources:
   url: http://ftpmirror.gnu.org/gcc/gcc-4.9.2/gcc-4.9.2.tar.bz2
 
 build_stages:
+  # Make gcc automatically embed RPATH to the proper libstdc++, libgfortran,
+  # libgcc and libquadmath libraries:
   - name: rpath_patch
     before: configure
     files: [rpath.patch]

--- a/pkgs/gcc/rpath.patch
+++ b/pkgs/gcc/rpath.patch
@@ -1,0 +1,24 @@
+diff --git a/gcc/config/i386/gnu-user.h b/gcc/config/i386/gnu-user.h
+index e1163c9..dc09728 100644
+--- a/gcc/config/i386/gnu-user.h
++++ b/gcc/config/i386/gnu-user.h
+@@ -79,6 +79,7 @@ along with GCC; see the file COPYING3.  If not see
+     %{!static: \
+       %{rdynamic:-export-dynamic} \
+       -dynamic-linker %(dynamic_linker)} \
++      -rpath @@ARTIFACT@@/lib \
+       %{static:-static}}"
+ 
+ #undef	LINK_SPEC
+diff --git a/gcc/config/i386/gnu-user64.h b/gcc/config/i386/gnu-user64.h
+index 1c72b41..457639b 100644
+--- a/gcc/config/i386/gnu-user64.h
++++ b/gcc/config/i386/gnu-user64.h
+@@ -63,6 +63,7 @@ see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see
+       %{" SPEC_32 ":-dynamic-linker " GNU_USER_DYNAMIC_LINKER32 "} \
+       %{" SPEC_64 ":-dynamic-linker " GNU_USER_DYNAMIC_LINKER64 "} \
+       %{" SPEC_X32 ":-dynamic-linker " GNU_USER_DYNAMIC_LINKERX32 "}} \
++      -rpath @@ARTIFACT@@/lib \
+     %{static:-static}}"
+ 
+ #undef	LINK_SPEC


### PR DESCRIPTION
The patch adds @@ARTIFACT@@ at the proper place in the source code and we then
replace it for ${ARTIFACT} using sed.