### PR TITLE
Add gdbm to default build dependencies for Python

### DIFF
--- a/pkgs/python/python.yaml
+++ b/pkgs/python/python.yaml
@@ -20,7 +20,7 @@ when pyver == '3.4':
 
 
 dependencies:
-  build: [zlib, bzip2, sqlite, openssl, launcher, ncurses, readline, {{build_with}}]
+  build: [zlib, bzip2, sqlite, openssl, launcher, ncurses, readline, gdbm, {{build_with}}]
   run: []
 
 defaults:


### PR DESCRIPTION
We often require Python to be built with `gdbm`, so it would be nice if this could be the default. What do you think?