### PR TITLE
bcfg2: update to 1.3.5 stable version

### DIFF
--- a/pkgs/bcfg2.yaml
+++ b/pkgs/bcfg2.yaml
@@ -5,5 +5,5 @@ dependencies:
   run: [ lockfile, lxml, python-daemon ]
 
 sources:
- - url: https://pypi.python.org/packages/source/B/Bcfg2/Bcfg2-1.3.4.tar.gz
-   key: tar.gz:kj3my2z3tqtj45fpnje7nuo4gy4iy2du
+- key: tar.gz:m6xs5ibzyfm2rdvcsec7ibmjwz32ba2z
+  url: http://ftp.mcs.anl.gov/pub/bcfg/bcfg2-1.3.5.tar.gz


### PR DESCRIPTION
This version is considered to be stable however it does not function
correctly on older versions of python (namely versions on EL5)