### PR TITLE
gcc: OSX has bsd sed, should depend on gnu sed

### DIFF
--- a/pkgs/gcc/gcc.yaml
+++ b/pkgs/gcc/gcc.yaml
@@ -2,7 +2,7 @@ extends: [autotools_package]
 
 # see https://gcc.gnu.org/install/prerequisites.html
 dependencies:
-  build: [zlib, mpfr, mpc, gmp, isl, cloog, {{build_with}}]
+  build: [zlib, mpfr, mpc, gmp, isl, cloog, gnu-sed, {{build_with}}]
 
 defaults:
   relocatable: false


### PR DESCRIPTION
Without this patch, gcc build fails with

	2015/02/21 08:56:16 - INFO: [package:run_job] sed: 1: "gcc/config/i386/gnu-user.h": extra characters at the end of g command
	2015/02/21 08:56:16 - ERROR: [package:run_job] Command '[u'/bin/bash', '_hashdist/build.sh']' returned non-zero exit status 1

Signed-off-by: Jimmy Tang <jcftang@gmail.com>