### PR TITLE
Remove TAO as additional DOLFIN dependency

### DIFF
--- a/pkgs/dolfin/dolfin.py
+++ b/pkgs/dolfin/dolfin.py
@@ -104,7 +104,7 @@ def configure(ctx, stage_args):
         conf_lines.append('-D ZLIB_ROOT="${ZLIB_DIR}"')
 
     optional_deps = ['CGAL', 'HDF5', 'PETSC', 'PETSC4PY', 'SLEPC',
-                     'TAO', 'TRILINOS', 'PASTIX', 'SCOTCH', 'PARMETIS',
+                     'TRILINOS', 'PASTIX', 'SCOTCH', 'PARMETIS',
                      'CGAL', 'ZLIB', 'PYTHON','SPHINX', 'VTK', 'QT']
 
     for dep in optional_deps:


### PR DESCRIPTION
Remove TAO as additional DOLFIN dependency. Since petsc-3.5 TAO is included in PETSC and should be automatically enabled and not considered any more as an additional dependency. The following configuration disable TAO from dolfin by default without any reason.