### PR TITLE
Add python as mshr dependence

### DIFF
--- a/pkgs/mshr.yaml
+++ b/pkgs/mshr.yaml
@@ -1,7 +1,7 @@
 extends: [cmake_package]
 
 dependencies:
-  build: [boost, dolfin, gmp, mpfr, mpi, swig, vtk, {{build_with}}]
+  build: [python, boost, dolfin, gmp, mpfr, mpi, swig, vtk, {{build_with}}]
 
 sources:
 - key: tar.gz:6nto4vmuuwnifcj6li7p7iv4mxzzdso4


### PR DESCRIPTION
I think that python should be added as a dependence for `mshr`. Without that, hashdist uses my (old!) system python (2.4 in my case). At least this addition solved my problem. I think that this will solve also this issue: http://fenicsproject.org/pipermail/fenics-support/2015-February/001299.html