### PR TITLE
Allow to set XLIBGL_CFLAGS/LIBS from a profile

### DIFF
--- a/pkgs/mesa.yaml
+++ b/pkgs/mesa.yaml
@@ -1,5 +1,9 @@
 extends: [autotools_package]
 
+dependencies:
+  build: [pkg-config]
+  run: []
+
 sources:
 - key: tar.bz2:a2rdiese5oc4fa7vt5ybmhqg33iqn6bv
   url: ftp://ftp.freedesktop.org/pub/mesa/10.2.4/MesaLib-10.2.4.tar.bz2
@@ -12,6 +16,8 @@ build_stages:
   handler: bash
   bash: |
     autoreconf -fi
+    export XLIBGL_CFLAGS="{{xlibgl_cflags}}"
+    export XLIBGL_LIBS="{{xlibgl_libs}}"
 
 - name: configure
   mode: override


### PR DESCRIPTION
For example on RHEL6, mesa needs the following profile:
```
  mesa:
    xlibgl_cflags: ' '
    xlibgl_libs: '-lXext -lX11'
```
If you build mesa just with the usual profile:
```
  mesa:
```
Then the two environment variables XLIBGL_CFLAGS and XLIBGL_LIBS will be empty,
and they should not affect the build (e.g. if mesa was working before, it
should continue working).

Fixes #675.