### PR TITLE
Add Numba

### DIFF
--- a/pkgs/enum34.yaml
+++ b/pkgs/enum34.yaml
@@ -1,0 +1,14 @@
+extends: [distutils_package]
+
+dependencies:
+  build: []
+  run: []
+
+sources:
+# The proper sources should be:
+#- key: tar.gz:2paz6jvgundctqmmo5pvtx6f3vmvozgh
+#  url: https://pypi.python.org/packages/source/e/enum34/enum34-1.0.4.tar.gz
+# But they don't work due to https://github.com/hashdist/hashdist/issues/310,
+# so we use this equivalent git repository:
+- key: git:dc35e72a5b4c6da1f0caaab1aaa13553e481e173
+  url: https://github.com/certik/enum34

--- a/pkgs/funcsigs.yaml
+++ b/pkgs/funcsigs.yaml
@@ -1,0 +1,9 @@
+extends: [setuptools_package]
+
+dependencies:
+  build: []
+  run: []
+
+sources:
+- key: tar.gz:3a6onxylb2tgdbya7yo3gu2smoi2ri5n
+  url: https://pypi.python.org/packages/source/f/funcsigs/funcsigs-0.4.tar.gz

--- a/pkgs/llvm.yaml
+++ b/pkgs/llvm.yaml
@@ -6,3 +6,7 @@ sources:
 
 defaults:
   relocatable: false
+
+when_build_dependency:
+- prepend_path: PATH
+  value: '${ARTIFACT}/bin'

--- a/pkgs/llvm.yaml
+++ b/pkgs/llvm.yaml
@@ -1,12 +1,8 @@
 extends: [cmake_package]
 
 sources:
-- url: http://llvm.org/releases/3.4/llvm-3.4.src.tar.gz
-  key: tar.gz:ewswclljfreeqg43hf7cwvpuq4hei6lg
+- key: tar.xz:x4zhluwxreablsgy6xtpj6ec7dhtx5iz
+  url: http://llvm.org/releases/3.5.1/llvm-3.5.1.src.tar.xz
 
 defaults:
   relocatable: false
-
-build_stages:
-- name: configure
-  extra: ['-D BUILD_SHARED_LIBS:BOOL=ON']

--- a/pkgs/llvmlite.yaml
+++ b/pkgs/llvmlite.yaml
@@ -1,7 +1,7 @@
 extends: [distutils_package]
 dependencies:
   build: [llvm]
-  run: []
+  run: [enum34]
 
 sources:
   - key: git:317245a28a26056cb2eef48831329ed8eb76491e

--- a/pkgs/llvmlite.yaml
+++ b/pkgs/llvmlite.yaml
@@ -1,0 +1,8 @@
+extends: [distutils_package]
+dependencies:
+  build: [llvm]
+  run: []
+
+sources:
+  - key: git:317245a28a26056cb2eef48831329ed8eb76491e
+    url: https://github.com/numba/llvmlite

--- a/pkgs/numba.yaml
+++ b/pkgs/numba.yaml
@@ -4,5 +4,5 @@ dependencies:
   run: [numpy, argparse, funcsigs]
 
 sources:
-  - key: git:772e4c0ad4bb07b329d65f6b9c40f097149431cd
+  - key: git:8267aed50bf0505de0689ae3cc45faa01353e4cc
     url: https://github.com/numba/numba

--- a/pkgs/numba.yaml
+++ b/pkgs/numba.yaml
@@ -1,7 +1,7 @@
 extends: [distutils_package]
 dependencies:
   build: [llvmlite, numpy]
-  run: []
+  run: [numpy, argparse, funcsigs]
 
 sources:
   - key: git:772e4c0ad4bb07b329d65f6b9c40f097149431cd

--- a/pkgs/numba.yaml
+++ b/pkgs/numba.yaml
@@ -1,0 +1,8 @@
+extends: [distutils_package]
+dependencies:
+  build: [llvmlite, numpy]
+  run: []
+
+sources:
+  - key: git:772e4c0ad4bb07b329d65f6b9c40f097149431cd
+    url: https://github.com/numba/numba


### PR DESCRIPTION
See commit logs. With this PR, one can execute the script from:

http://matthewrocklin.com/blog/work/2015/02/28/Ising/

I.e.:
```
$ python ising.py 
/home/certik/repos/hashstack/default/lib/python2.7/site-packages/numba/__init__.py:73: UserWarning: llvmlite version format not recognized!
  warnings.warn("llvmlite version format not recognized!")
$
```