### PR TITLE
[WIP] Add Dragonegg

### DIFF
--- a/pkgs/dragonegg.yaml
+++ b/pkgs/dragonegg.yaml
@@ -1,0 +1,15 @@
+extends: [base_package, libflags]
+
+dependencies:
+  build: [llvm, gmp, gcc]
+
+sources:
+- key: tar.xz:mxtzosruibsghtp3rqf23vg74kj6xz3r
+  url: http://llvm.org/releases/3.5.1/dragonegg-3.5.1.src.tar.xz
+
+build_stages:
+- name: make
+  after: prologue
+  handler: bash
+  bash: |
+    make


### PR DESCRIPTION
This depends on #685.

Currently it fails with:
```
[dragonegg] Compiling utils/TargetInfo.cpp
[dragonegg] Linking TargetInfo
[dragonegg] Compiling Aliasing.cpp
[dragonegg] Compiling Backend.cpp
[dragonegg] /local/certik/tmp/dragonegg-nrce3fcduhrt/src/Backend.cpp:87:23: fatal error: tree-flow.h: No such file or directory
[dragonegg]  #include "tree-flow.h"
[dragonegg]                        ^
[dragonegg] compilation terminated.
[dragonegg] make: *** [Backend.o] Error 1
```