### PR TITLE
Adding fftw_all.yaml and pyfftw.yaml. 

### DIFF
--- a/pkgs/fftw_all.yaml
+++ b/pkgs/fftw_all.yaml
@@ -1,0 +1,36 @@
+extends: [autotools_package]
+dependencies:
+  build: [mpi]
+
+sources:
+- url: http://www.fftw.org/fftw-3.3.3.tar.gz
+  key: tar.gz:qxg7ycqluegy7jhq7dtthkwbuwjwzbmy
+
+defaults:
+  # lib/libfftw3.la contains hard-coded path
+  relocatable: false
+
+build_stages:
+- name: configure
+  extra: ['--disable-debug', '--enable-shared', '--enable-mpi',
+          '--enable-sse2', '--enable-avx', '--enable-threads']
+
+- name: install
+  after: make
+  handler: bash
+  mode: override
+  bash: |
+    make install
+    make clean
+    # Build single precision library as well:
+    ./configure --prefix=$ARTIFACT --enable-single --disable-debug \
+            --enable-shared --enable-mpi --enable-sse2 --enable-avx \
+            --enable-threads
+    make -j ${HASHDIST_CPU_COUNT}
+    make install
+    make clean
+    # Build long double precision library as well:
+    ./configure --prefix=$ARTIFACT --enable-long-double --disable-debug \
+            --enable-shared --enable-mpi --enable-threads
+    make -j ${HASHDIST_CPU_COUNT}
+    make install

--- a/pkgs/pyfftw.yaml
+++ b/pkgs/pyfftw.yaml
@@ -1,0 +1,17 @@
+extends: [distutils_package]
+
+dependencies:
+  build: [fftw, mpi4py, mpi, numpy, cython]
+  run: [numpy]
+
+sources:
+- key: tar.gz:6253nl5jgccubgvsjcc2di6nxcij6ck2
+  url: https://pypi.python.org/packages/source/p/pyFFTW/pyFFTW-0.9.2.tar.gz
+
+build_stages:
+- name: install
+  after: setup_dirs
+  handler: bash
+  bash: |
+    ${PYTHON} setup.py build_ext --inplace --library-dirs=$ARTIFACT/lib --include-dirs=$ARTIFACT/include
+    ${PYTHON} setup.py install --prefix=$ARTIFACT


### PR DESCRIPTION
fftw_all.yaml is a slight modification of original fftw.yaml that builds both single, double and long double versions of the fftw library. All these precision libraries are required by pyfftw, which is a Python wrapper of fftw.

I have only tested this on my own Ubuntu 14.10.