### PR TITLE
Add the ExodusII library

### DIFF
--- a/pkgs/exodus/exodus.yaml
+++ b/pkgs/exodus/exodus.yaml
@@ -1,0 +1,37 @@
+extends: [cmake_package]
+
+dependencies:
+  build: [zlib, curl, netcdf4, hdf5, python, openssl, mpi]
+  run: [numpy]
+
+sources:
+- key: tar.gz:4fg3jqpczketyrqcavidnobhxazsorsd
+  url: http://downloads.sourceforge.net/project/exodusii/exodus-6.09.tar.gz
+
+defaults:
+  # lib/python2.7/site-packages/exodus.py contains hard-coded path
+  relocatable: false
+
+build_stages:
+
+- name: patch
+  before: switch_dir
+  files: [include_path_fix.patch]
+  handler: bash
+  bash: |
+    patch -up1 < _hashdist/include_path_fix.patch
+
+- name: switch_dir
+  after: prologue
+  before: setup_builddir
+  handler: bash
+  bash: |
+    cd exodus
+
+- name: configure
+  extra: ['-D BUILD_SHARED=ON',
+          '-D NETCDF_SO_ROOT:PATH="${NETCDF4_DIR}/lib"',
+          '-D PYTHON_INSTALL:PATH="${ARTIFACT}/{{python_site_packages_rel}}"',
+          ]
+
+licenses: [bsd-2-clause]

--- a/pkgs/exodus/include_path_fix.patch
+++ b/pkgs/exodus/include_path_fix.patch
@@ -1,0 +1,23 @@
+commit 78d4d2202a2861ef618f4e7f394e545a9a6d2339
+Author: Ondřej Čertík <ondrej.certik@gmail.com>
+Date:   Fri Mar 6 14:00:09 2015 -0700
+
+    Fix include path
+    
+    The Python script requires access to exodusII.h, but it is importing it from
+    $PREFIX/inc, instead of $PREFIX/include. This patch fixes it.
+
+diff --git a/exodus/exodus.py.in b/exodus/exodus.py.in
+index 3784ae9..b54938c 100644
+--- a/exodus/exodus.py.in
++++ b/exodus/exodus.py.in
+@@ -56,7 +56,7 @@ def getExodusVersion():
+   Parse the exodusII.h header file and return the version number or 0 if not
+   found.
+   """
+-  for line in open(getAccessPath() + '/inc/exodusII.h'):
++  for line in open(getAccessPath() + '/include/exodusII.h'):
+     fields = line.split()
+     if (len(fields) == 3 and
+         fields[0] == '#define' and
+


### PR DESCRIPTION
The Python wrappers work great with Hashdist, after I patched them (also the `NETCDF_SO_ROOT` and `PYTHON_INSTALL` must be set when calling cmake, those variables are then hardwired in the python wrapper, otherwise the `exodus` module fails to import). Here is an example of usage:
```
In [1]: from exodus import exodus

In [2]: e = exodus('furnace.exo', array_type='numpy')

You are using exodus.py v 1.02 (beta), a python wrapper of some of the exodus II library.
Copyright (c) 2013,2014 Sandia Corporation. Under the terms of Contract DE-AC04-94AL85000
with Sandia Corporation, the U.S. Government retains certain rights in this software.

Opening exodus file: furnace.exo

In [3]: e.get_elem_id_map()
Out[3]: array([       1,        2,        3, ..., 15525656, 15525657, 15525658])
```