### PR TITLE
Update cbcblock.yaml

### DIFF
--- a/pkgs/cbcblock.yaml
+++ b/pkgs/cbcblock.yaml
@@ -4,5 +4,5 @@ dependencies:
   run: [dolfin, numpy, petsc4py, scipy, trilinos, ufl]
 
 sources:
-- key: git:a678b8f6f2f0184af6709fe6d7a179aecacd6672
+- key: git:567730c8448f19674588667c4ec959026c2b78f4
   url: https://bitbucket.org/fenics-apps/cbc.block.git


### PR DESCRIPTION
The previous version was using an old PETSc interface and this resulted in error `AttributeError: type object 'MatStructure' has no attribute 'SAME_PRECONDITIONER’` whenever ML preconditioner was constructed. Yaml now points to the lastest commit in cbc.block where the
error is fixed