### PR TITLE
Add Shapely (Development branch)

### DIFF
--- a/pkgs/geos.yaml
+++ b/pkgs/geos.yaml
@@ -3,3 +3,7 @@ extends: [autotools_package]
 sources:
   - url: http://download.osgeo.org/geos/geos-3.4.2.tar.bz2
     key: tar.bz2:cxul7x36feehvfl3k2wfipvjvabscsa4
+
+when_build_dependency:
+  - prepend_path: PATH
+    value: '${ARTIFACT}/bin'

--- a/pkgs/shapely.yaml
+++ b/pkgs/shapely.yaml
@@ -1,0 +1,16 @@
+extends: [distutils_package]
+dependencies:
+  build: [geos]
+  run: [geos]
+
+sources:
+- key: git:76f5832e8df80ed86493fb4eb7a0cd7a17976822
+  url: git@github.com:Toblerity/Shapely.git
+
+build_stages:
+- name: check
+  after: install
+  handler: bash
+  bash: |
+    ${PYTHON} -c "from shapely import geos"
+


### PR DESCRIPTION
We can't use a release since we need
https://github.com/Toblerity/Shapely/pull/241

This also requires:
https://github.com/hashdist/hashdist/commit/d3a39c57