### PR TITLE
set OPENBLAS_DIR in openblas.yaml when build dependencies

### DIFF
--- a/pkgs/openblas.yaml
+++ b/pkgs/openblas.yaml
@@ -19,3 +19,4 @@ build_stages:
 when_build_dependency:
 - {set: 'BLAS_LDFLAGS', value: '-Wl,-rpath,${ARTIFACT}/lib -L${ARTIFACT}/lib -lopenblas'}
 - {set: 'LAPACK_LDFLAGS', value: '-Wl,-rpath,${ARTIFACT}/lib -L${ARTIFACT}/lib -lopenblas'}
+- {set: 'OPENBLAS_DIR', value: '${ARTIFACT}'}


### PR DESCRIPTION
I found that the numpy package is not able to find openblas at compile time, because it is looking in `$OPENBLAS_DIR/lib` and `OPENBLAS_DIR` is not set in `openblas.yaml `. I think that this setting should be unable. At least with this change numpy finds openblas for me.