### PR TITLE
Add coffeescript

### DIFF
--- a/pkgs/coffeescript.yaml
+++ b/pkgs/coffeescript.yaml
@@ -1,0 +1,20 @@
+extends: [base_package]
+dependencies:
+  build: [node]
+
+defaults:
+  relocatable: false
+
+sources:
+- key: tar.gz:uwx36n3nhdu7dwxtwp46sffv3t3orhtw
+  url: https://github.com/jashkenas/coffeescript/archive/1.9.1.tar.gz
+
+build_stages:
+-  name: install
+   mode: replace
+   handler: bash
+   after: prologue
+   bash: |
+     "$NODE_DIR"/bin/npm --proxy 127.0.0.1:2 --production --global \
+         --prefix="$ARTIFACT" install .
+


### PR DESCRIPTION
This is a bit of an experiment in packaging node.js modules. Since there is basically no stable node.js module, the node package manager makes private installs of all dependencies for each package (recursively).

However, the coffeescript transpiler has no dependencies so its actually easy ;-)