### PR TITLE
Update doxygen.yaml to set dependency on Flex

### DIFF
--- a/pkgs/doxygen.yaml
+++ b/pkgs/doxygen.yaml
@@ -1,7 +1,7 @@
 extends: [autotools_package]
 
 dependencies:
-  build: [bison]
+  build: [bison,flex]
 
 sources:
 - url: https://github.com/doxygen/doxygen.git


### PR DESCRIPTION
Doxygen has a dependency on Flex. See build log here:

```
2015/04/23 21:57:58 - INFO: [package:run_job]   Autodetected platform linux-g++... 
2015/04/23 21:57:58 - INFO: [package:run_job]   Checking for GNU make tool... using /usr/bin/make
2015/04/23 21:57:58 - INFO: [package:run_job]   Checking for GNU install tool... using /usr/bin/install
2015/04/23 21:57:58 - INFO: [package:run_job]   Checking for dot (part of GraphViz)... using /usr/bin/dot
2015/04/23 21:57:59 - INFO: [package:run_job]   Checking for python... using /home/villanueva/.hashdist/bld/profile/7zzysldrvpy3/bin/python2
2015/04/23 21:57:59 - INFO: [package:run_job]   Checking for perl... using /usr/bin/perl
2015/04/23 21:57:59 - INFO: [package:run_job]   Checking for flex... not found!
2015/04/23 21:57:59 - ERROR: [package:run_job] Command '[u'/bin/bash', '_hashdist/build.sh']' returned non-zero exit status 1
2015/04/23 21:57:59 - ERROR: [package:run_job] command failed (code=1); raising
```