### PR TITLE
httpie: initial add of package, this is a curl alternative

### DIFF
--- a/pkgs/httpie.yaml
+++ b/pkgs/httpie.yaml
@@ -1,0 +1,8 @@
+extends: [setuptools_package]
+
+dependencies:
+  build: [pygments]
+
+sources:
+ - key: tar.gz:v44yfvaxipmymyepd7toin6qje67ej4z
+   url: https://pypi.python.org/packages/source/h/httpie/httpie-0.9.2.tar.gz


### PR DESCRIPTION
This is a curl alternative and is very useful for testing against web based api's