### PR TITLE
update IPython to 3.1

### DIFF
--- a/pkgs/backports-ssl_match_hostname.yaml
+++ b/pkgs/backports-ssl_match_hostname.yaml
@@ -1,9 +1,5 @@
 extends: [setuptools_package]
 
-dependencies:
-  build: []
-  run: []
-
 sources:
 - key: tar.gz:a5aq475qtkvxxwxv4ymn4zwd3lee4lr5
   url: https://pypi.python.org/packages/source/b/backports.ssl_match_hostname/backports.ssl_match_hostname-3.4.0.2.tar.gz

--- a/pkgs/backports-ssl_match_hostname.yaml
+++ b/pkgs/backports-ssl_match_hostname.yaml
@@ -1,0 +1,9 @@
+extends: [setuptools_package]
+
+dependencies:
+  build: []
+  run: []
+
+sources:
+- key: tar.gz:a5aq475qtkvxxwxv4ymn4zwd3lee4lr5
+  url: https://pypi.python.org/packages/source/b/backports.ssl_match_hostname/backports.ssl_match_hostname-3.4.0.2.tar.gz

--- a/pkgs/ipython.yaml
+++ b/pkgs/ipython.yaml
@@ -1,7 +1,7 @@
 extends: [distutils_package]
 dependencies:
-  run: [pyzmq, tornado, jinja2, pygments, sphinx]
+  run: [pyzmq, tornado, jinja2, jsonschema, pygments, sphinx]
 
 sources:
-  - url: https://pypi.python.org/packages/source/i/ipython/ipython-2.3.0.tar.gz
-    key: tar.gz:ul4bv7r6zjoiwlum6twdkump2ad2herr
+  - url: https://pypi.python.org/packages/source/i/ipython/ipython-3.1.0.tar.gz
+    key: tar.gz:kmqjfu7qn6bldwgr4xbxbf7k4gp46as7

--- a/pkgs/jinja2.yaml
+++ b/pkgs/jinja2.yaml
@@ -1,5 +1,8 @@
 extends: [setuptools_package]
 
+dependencies:
+  run: [MarkupSafe]
+
 sources:
 - key: tar.gz:fyskyxiajw2xcslwubfmb2amnx3oi7uy
   url: https://pypi.python.org/packages/source/J/Jinja2/Jinja2-2.7.3.tar.gz

--- a/pkgs/tornado.yaml
+++ b/pkgs/tornado.yaml
@@ -1,5 +1,8 @@
 extends: [distutils_package]
+dependencies:
+  run: [backports-ssl_match_hostname]
+
 
 sources:
-  - url: https://pypi.python.org/packages/source/t/tornado/tornado-3.1.1.tar.gz
-    key: tar.gz:grmqjp7eudhf22dsap3yhgdkoph5pxb2
+  - url: https://pypi.python.org/packages/source/t/tornado/tornado-4.1.tar.gz
+    key: tar.gz:tgv5hlw6ixetoojun3ttqttraeqbehbx


### PR DESCRIPTION
- add missing dependency on markupsafe to jinja2
- add missing dependency on jsonschema to ipython
- update tornado to 4.1 (required for IPython 3)
- add backports.ssl_match_hostname (required for tornado 4)