### PR TITLE
openjpeg 1.5.1 from dev site, used by grib_api

### DIFF
--- a/pkgs/openjpeg.yaml
+++ b/pkgs/openjpeg.yaml
@@ -1,0 +1,24 @@
+extends: [cmake_package]
+
+# version 1.5 of openjpeg
+# later versions should go in openjpeg2
+
+dependencies:
+  build: []
+
+defaults:
+  relocatable: false
+
+sources:
+- key: tar.gz:nt5tbf5bzduvkajrwf3ghwxze72cob54
+  url: https://openjpeg.googlecode.com/files/openjpeg-1.5.1.tar.gz
+
+build_stages:
+
+# grib_api, at least, expects not to find this namespaced
+- name: fix_include
+  after: install
+  handler: bash
+  bash: |
+    ln -s ${ARTIFACT}/include/openjpeg-1.5/openjpeg.h ${ARTIFACT}/include/openjpeg.h
+

--- a/pkgs/openjpeg.yaml
+++ b/pkgs/openjpeg.yaml
@@ -10,8 +10,8 @@ defaults:
   relocatable: false
 
 sources:
-- key: tar.gz:nt5tbf5bzduvkajrwf3ghwxze72cob54
-  url: https://openjpeg.googlecode.com/files/openjpeg-1.5.1.tar.gz
+- key: tar.gz:cizlxakp3cgy5uyuzfhqx7v3appikwky
+  url: http://sourceforge.net/projects/openjpeg.mirror/files/2.1.0/openjpeg-2.1.0.tar.gz
 
 build_stages:
 


### PR DESCRIPTION
Note: I couldn't get pillow to use this as its jpeg2000 lib