### PR TITLE
added options for <#> versions of png(zlib), freetype, and jpeg2K

### DIFF
--- a/base/setuptools_package.yaml
+++ b/base/setuptools_package.yaml
@@ -22,6 +22,7 @@ build_stages:
   handler: bash
   bash: |
     ${PYTHON} -c 'import setuptools; __file__="setup.py"; exec(open(__file__).read())' \
+       ${SETUPTOOLS_PACKAGE_EXTRA_OPTIONS} \
        install \
        --prefix=. --root=${ARTIFACT} \
        --single-version-externally-managed

--- a/pkgs/pillow.yaml
+++ b/pkgs/pillow.yaml
@@ -12,7 +12,4 @@ build_stages:
   before: install
   handler: bash
   bash: |
-       export SETUPTOOLS_PACKAGE_EXTRA_OPTIONS=build_ext \
-       --enable-zlib --enable-freetype --enable-jpeg2000 \
-       --include-dirs="${ZLIB_DIR}/include:${PNG_DIR}/include:${FREETYPE_DIR}/include:${OPENJPEG_DIR}/include" \
-       --library-dirs="${ZLIB_DIR}/lib:${PNG_DIR}/lib:${FREETYPE_DIR}/lib:${OPENJPEG_DIR}/lib"
+       export SETUPTOOLS_PACKAGE_EXTRA_OPTIONS="build_ext --enable-zlib --enable-freetype --enable-jpeg2000 --include-dirs=${ZLIB_DIR}/include:${PNG_DIR}/include:${FREETYPE_DIR}/include:${OPENJPEG_DIR}/include --library-dirs=${ZLIB_DIR}/lib:${PNG_DIR}/lib:${FREETYPE_DIR}/lib:${OPENJPEG_DIR}/lib"

--- a/pkgs/pillow.yaml
+++ b/pkgs/pillow.yaml
@@ -1,6 +1,6 @@
 extends: [setuptools_package]
 dependencies:
-  build: [zlib,png,freetype,openjpeg]
+  build: [zlib, png, freetype, openjpeg]
 
 sources:
 - key: tar.gz:q5qmcgfaefplufr7o6bbcdt67tn3cx4k

--- a/pkgs/pillow.yaml
+++ b/pkgs/pillow.yaml
@@ -7,15 +7,12 @@ sources:
   url: https://pypi.python.org/packages/source/P/Pillow/Pillow-2.8.1.tar.gz
 
 build_stages:
-- name: install
+- name: build_ext_options
   mode: replace
+  before: install
   handler: bash
   bash: |
-       ${PYTHON} -c 'import setuptools; __file__="setup.py"; exec(open(__file__).read())' \
-       build_ext \
+       SETUPTOOLS_PACKAGE_EXTRA_OPTIONS=build_ext \
        --enable-zlib --enable-freetype --enable-jpeg2000 \
        --include-dirs="${ZLIB_DIR}/include:${PNG_DIR}/include:${FREETYPE_DIR}/include:${OPENJPEG_DIR}/include" \
-       --library-dirs="${ZLIB_DIR}/lib:${PNG_DIR}/lib:${FREETYPE_DIR}/lib:${OPENJPEG_DIR}/lib" \
-       install \
-       --prefix=. --root=${ARTIFACT} \
-       --single-version-externally-managed
+       --library-dirs="${ZLIB_DIR}/lib:${PNG_DIR}/lib:${FREETYPE_DIR}/lib:${OPENJPEG_DIR}/lib"

--- a/pkgs/pillow.yaml
+++ b/pkgs/pillow.yaml
@@ -1,7 +1,21 @@
 extends: [setuptools_package]
 dependencies:
-  build: [png]
+  build: [zlib,png,freetype,openjpeg]
 
 sources:
 - key: tar.gz:q5qmcgfaefplufr7o6bbcdt67tn3cx4k
   url: https://pypi.python.org/packages/source/P/Pillow/Pillow-2.8.1.tar.gz
+
+build_stages:
+- name: install
+  mode: replace
+  handler: bash
+  bash: |
+       ${PYTHON} -c 'import setuptools; __file__="setup.py"; exec(open(__file__).read())' \
+       build_ext \
+       --enable-zlib --enable-freetype --enable-jpeg2000 \
+       --include-dirs="${ZLIB_DIR}/include:${PNG_DIR}/include:${FREETYPE_DIR}/include:${OPENJPEG_DIR}/include" \
+       --library-dirs="${ZLIB_DIR}/lib:${PNG_DIR}/lib:${FREETYPE_DIR}/lib:${OPENJPEG_DIR}/lib" \
+       install \
+       --prefix=. --root=${ARTIFACT} \
+       --single-version-externally-managed

--- a/pkgs/pillow.yaml
+++ b/pkgs/pillow.yaml
@@ -12,7 +12,7 @@ build_stages:
   before: install
   handler: bash
   bash: |
-       SETUPTOOLS_PACKAGE_EXTRA_OPTIONS=build_ext \
+       export SETUPTOOLS_PACKAGE_EXTRA_OPTIONS=build_ext \
        --enable-zlib --enable-freetype --enable-jpeg2000 \
        --include-dirs="${ZLIB_DIR}/include:${PNG_DIR}/include:${FREETYPE_DIR}/include:${OPENJPEG_DIR}/include" \
        --library-dirs="${ZLIB_DIR}/lib:${PNG_DIR}/lib:${FREETYPE_DIR}/lib:${OPENJPEG_DIR}/lib"


### PR DESCRIPTION
added the bits that point to the hashstack versions of  the dependencies and enforces  the related support in PIL.