### PR TITLE
add -R switch to ode python bindings

### DIFF
--- a/pkgs/ode.yaml
+++ b/pkgs/ode.yaml
@@ -24,4 +24,4 @@ build_stages:
   handler: bash
   bash: |
     cd bindings/python
-    PKG_CONFIG_PATH=../.. ${PYTHON} setup.py install --prefix=${ARTIFACT}
+    PKG_CONFIG_PATH=../.. ${PYTHON} setup.py build_ext -R ${ARTIFACT}/lib install --prefix=${ARTIFACT}


### PR DESCRIPTION
This eliminates the need for setting LD_LIBRARY_PATH when running ode from python.