### PR TITLE
Fix CMake on OSX 10.10

### DIFF
--- a/base/cmake_package.py
+++ b/base/cmake_package.py
@@ -34,6 +34,9 @@ def configure(ctx, stage_args):
     else:
         conf_lines.append('-DCMAKE_BUILD_TYPE:STRING=Release')
 
+    if ctx.parameters['platform'] == 'Darwin':
+        conf_lines.append('-DCMAKE_OSX_DEPLOYMENT_TARGET:STRING=""')
+
     #cmake needs to be given all the dependency dirs as prefix paths
     #so that we search the hashdist directories before the system directories
     #CMake doesn't use the CPPFLAGS implicitly to find libraries

--- a/pkgs/cmake.yaml
+++ b/pkgs/cmake.yaml
@@ -8,6 +8,14 @@ sources:
   url: http://www.cmake.org/files/v3.2/cmake-3.2.2.tar.gz
 
 build_stages:
+- when: platform == 'Darwin'
+  name: fix_deployment_target
+  after: prologue
+  before: configure
+  handler: bash
+  bash: |
+    unset MACOSX_DEPLOYMENT_TARGET
+
 - name: configure
   extra: ['--parallel=${HASHDIST_CPU_COUNT}',
           '--system-bzip2',

--- a/pkgs/cmake.yaml
+++ b/pkgs/cmake.yaml
@@ -1,12 +1,24 @@
 extends: [autotools_package]
 
+dependencies:
+  build: [zlib, bzip2, curl]
+
 sources:
 - key: tar.gz:vxuu43rwaodxivs7flwyqzsbkrbuit5x
   url: http://www.cmake.org/files/v3.2/cmake-3.2.2.tar.gz
 
 build_stages:
 - name: configure
-  extra: ['--parallel=${HASHDIST_CPU_COUNT}']
+  extra: ['--parallel=${HASHDIST_CPU_COUNT}',
+          '--system-bzip2',
+          '--system-curl',
+          #'--system-expat',
+          #'--system-jsoncpp',
+          #'--system-libarchive',
+          '--system-zlib',
+          '--',
+          '-DCMAKE_PREFIX_PATH=${CURL_DIR}/lib;${ZLIB_DIR}/lib;${BZIP2_DIR}/lib',
+          ]
 
 when_build_dependency:
 - set: CMAKE

--- a/pkgs/cmake.yaml
+++ b/pkgs/cmake.yaml
@@ -1,8 +1,8 @@
 extends: [autotools_package]
 
 sources:
-- key: tar.gz:kcrzjtzo7wnjfxkbctv6fgmurgmezzxg
-  url: http://www.cmake.org/files/v3.2/cmake-3.2.0-rc1.tar.gz
+- key: tar.gz:vxuu43rwaodxivs7flwyqzsbkrbuit5x
+  url: http://www.cmake.org/files/v3.2/cmake-3.2.2.tar.gz
 
 build_stages:
 - name: configure

--- a/pkgs/cmake.yaml
+++ b/pkgs/cmake.yaml
@@ -1,7 +1,7 @@
 extends: [autotools_package]
 
 dependencies:
-  build: [zlib, bzip2, curl]
+  build: [zlib, bzip2, curl, openssl, libidn]
 
 sources:
 - key: tar.gz:vxuu43rwaodxivs7flwyqzsbkrbuit5x
@@ -26,6 +26,9 @@ build_stages:
           '--system-zlib',
           '--',
           '-DCMAKE_PREFIX_PATH=${CURL_DIR}/lib;${ZLIB_DIR}/lib;${BZIP2_DIR}/lib',
+          '-DCURL_INCLUDE_DIR=${CURL_DIR}/include',
+          '-DZLIB_INCLUDE_DIR=${ZLIB_DIR}/include',
+          '-DBZIP2_INCLUDE_DIR=${BZIP2_DIR}/include',
           ]
 
 when_build_dependency:

--- a/pkgs/cmake.yaml
+++ b/pkgs/cmake.yaml
@@ -1,7 +1,7 @@
 extends: [autotools_package]
 
 dependencies:
-  build: [zlib, bzip2, curl, openssl, libidn]
+  build: [zlib, bzip2, curl, openssl, libidn, expat]
 
 sources:
 - key: tar.gz:vxuu43rwaodxivs7flwyqzsbkrbuit5x
@@ -20,15 +20,16 @@ build_stages:
   extra: ['--parallel=${HASHDIST_CPU_COUNT}',
           '--system-bzip2',
           '--system-curl',
-          #'--system-expat',
+          '--system-expat',
           #'--system-jsoncpp',
           #'--system-libarchive',
           '--system-zlib',
           '--',
-          '-DCMAKE_PREFIX_PATH=${CURL_DIR}/lib;${ZLIB_DIR}/lib;${BZIP2_DIR}/lib',
+          '-DCMAKE_PREFIX_PATH=${CURL_DIR}/lib;${ZLIB_DIR}/lib;${BZIP2_DIR}/lib;${EXPAT_DIR}/lib',
           '-DCURL_INCLUDE_DIR=${CURL_DIR}/include',
           '-DZLIB_INCLUDE_DIR=${ZLIB_DIR}/include',
           '-DBZIP2_INCLUDE_DIR=${BZIP2_DIR}/include',
+          '-DEXPAT_INCLUDE_DIR=${EXPAT_DIR}/include',
           ]
 
 when_build_dependency:


### PR DESCRIPTION
See the commit messages for more information.

This is a change in an important package, so let's check that it (at the latest commit 9aed1265a8886a5e514ba78813953fd2c94e16d5):

* [x] compiles with gcc on OS X
* [x] compiles with the native clang on OS X
* [x] compiles on linux with gcc

Fixes #746.

This is ready for review.