### PR TITLE
git: allow to set NO_APPLE_COMMON_CRYPTO=1

### DIFF
--- a/pkgs/git.yaml
+++ b/pkgs/git.yaml
@@ -10,6 +10,7 @@ sources:
 defaults:
   # /bin/git contains hard-coded path
   relocatable: false
+  disable_crypto: false
 
 build_stages:
 
@@ -18,6 +19,13 @@ build_stages:
   handler: bash
   bash: |
     export PERL_PATH="/usr/bin/env perl"
+
+- when: platform == 'Darwin' and disable_crypto
+  name: fix_crypto_compile_failure
+  before: configure
+  handler: bash
+  bash: |
+    export NO_APPLE_COMMON_CRYPTO=1
 
 - name: configure
   mode: override


### PR DESCRIPTION
This fixes a build failure on OS X 10.10. Unfortunately, this disabled https
access, so it is only enabled if 'disable_crypto' parameter is 'true'.