### PR TITLE
Use Clang's linker to make AVX instructions work

### DIFF
--- a/pkgs/csympy.yaml
+++ b/pkgs/csympy.yaml
@@ -12,6 +12,12 @@ defaults:
   relocatable: false
 
 build_stages:
+- name: cxx_flags
+  before: configure
+  handler: bash
+  bash: |
+    export CXXFLAGS="-Wa,-q"
+
 - name: configure
   extra: ['-D WITH_PYTHON:BOOL=ON',
           '-D PYTHON_INSTALL_PATH:PATH=$ARTIFACT/{{python_site_packages_rel}}']


### PR DESCRIPTION
Fixes #748

However, I am not happy that we need to patch every package that uses our gcc. Rather, this patch should probably go into some base template, so that all packages use it.