### PR TITLE
Unset MACOSX_DEPLOYMENT_TARGET for all cmake

### DIFF
--- a/base/cmake_package.yaml
+++ b/base/cmake_package.yaml
@@ -12,6 +12,14 @@ build_stages:
       mkdir -p _build
       cd _build
 
+  - when: platform == 'Darwin'
+    name: fix_deployment_target
+    after: prologue
+    before: configure
+    handler: bash
+    bash: |
+      unset MACOSX_DEPLOYMENT_TARGET
+
   - name: configure
     after: setup_builddir
     debug: {{debug}}

--- a/pkgs/parmetis/parmetis.yaml
+++ b/pkgs/parmetis/parmetis.yaml
@@ -60,6 +60,7 @@ build_stages:
   handler: bash
   bash: |
     CMAKE_FLAGS="${CMAKE_FLAGS} -DCMAKE_MACOSX_RPATH:BOOL=ON"
+    unset MACOSX_DEPLOYMENT_TARGET
 
 - name: configure
   after: cmake-flags


### PR DESCRIPTION
This is needed, otherwise cmake fails to compile packages.