### PR TITLE
boost: run patchelf on the libraries, not on the symlinks

### DIFF
--- a/pkgs/boost/boost.yaml
+++ b/pkgs/boost/boost.yaml
@@ -91,7 +91,7 @@ build_stages:
   after: bjam
   handler: bash
   bash: |
-    for lib in ${ARTIFACT}/lib/*.so; do
+    for lib in ${ARTIFACT}/lib/*.so.*; do
         ${PATCHELF} --set-rpath ${ARTIFACT}/lib:${BZIP2_DIR}/lib:${ZLIB_DIR}/lib ${lib}
     done
 


### PR DESCRIPTION
This will fix #781.