### PR TITLE
Refactor out-of-source build with CMake

### DIFF
--- a/base/cmake_package.py
+++ b/base/cmake_package.py
@@ -51,9 +51,14 @@ def configure(ctx, stage_args):
     if 'extra' in stage_args:
         conf_lines.append(' '.join('%s' % arg for arg in stage_args['extra']))
 
+    #set in-source or out-of-source build
+    setup_lines = []
+    mkdirbuild = 'mkdir -p _build && cd _build'
     builddir = stage_args.get('builddir', '..')
     if stage_args.get('build_in_source', False):
+	mkdirbuild = ''
         builddir = '.'
+    setup_lines.append(mkdirbuild)
     conf_lines.append(builddir)
 
     for i in range(len(conf_lines) - 1):
@@ -65,4 +70,4 @@ def configure(ctx, stage_args):
         env_lines.append('export CPPFLAGS="%s"' % ' '.join(CPPFLAGS))
         env_lines.append('export LDFLAGS="%s"' % ' '.join(LDFLAGS))
 
-    return ['('] + env_lines + conf_lines + [')']
+    return setup_lines + ['('] + env_lines + conf_lines + [')']

--- a/base/cmake_package.yaml
+++ b/base/cmake_package.yaml
@@ -5,15 +5,8 @@ dependencies:
 
 build_stages:
 
-  - name: setup_builddir
-    after: prologue
-    handler: bash
-    bash: |
-      mkdir -p _build
-      cd _build
-
   - name: configure
-    after: setup_builddir
+    after: prologue
     debug: {{debug}}
 
   - name: make

--- a/pkgs/armadillo.yaml
+++ b/pkgs/armadillo.yaml
@@ -10,4 +10,4 @@ sources:
 build_stages:
 
   - name: configure
-    build_in_source: false
+    build_in_source: true

--- a/pkgs/armadillo.yaml
+++ b/pkgs/armadillo.yaml
@@ -8,11 +8,6 @@ sources:
   url: http://sourceforge.net/projects/arma/files/armadillo-5.100.2.tar.gz
 
 build_stages:
-  - name: setup_builddir
-    after: prologue
-    mode: replace
-    handler: bash
-    bash: |
 
   - name: configure
-    build_in_source: true
+    build_in_source: false

--- a/pkgs/dftatom.yaml
+++ b/pkgs/dftatom.yaml
@@ -1,3 +1,4 @@
+
 extends: [cmake_package]
 dependencies:
   build: [python, cython, numpy]
@@ -17,6 +18,3 @@ build_stages:
           '-D PYTHON_INSTALL_PATH:PATH=$ARTIFACT/{{python_site_packages_rel}}']
   build_in_source: true
 
-- name: setup_builddir
-  mode: override
-  bash: |

--- a/pkgs/dolfin/dolfin.py
+++ b/pkgs/dolfin/dolfin.py
@@ -16,6 +16,7 @@ def configure(ctx, stage_args):
         - name: configure
           build_type: Release
           set_env_flags: true
+          build_in_source: false
 
     Note: this is a fairly sophisticated build stage that inspects
     the build artifacts available to decide what to enable in DOLFIN.
@@ -114,9 +115,14 @@ def configure(ctx, stage_args):
         else:
             conf_lines.append('-D DOLFIN_ENABLE_%s:BOOL=OFF' % dep)
 
-    builddir = '..'
+    # Set in-source or out-of-source build
+    setup_lines = []
+    mkdirbuild = 'mkdir -p _build && cd _build'
+    builddir = stage_args.get('builddir', '..')
     if stage_args.get('build_in_source', False):
+        mkdirbuild = ''
         builddir = '.'
+    setup_lines.append(mkdirbuild)
     conf_lines.append(builddir)
 
     for i in range(len(conf_lines) - 1):
@@ -128,4 +134,4 @@ def configure(ctx, stage_args):
         env_lines.append('export CPPFLAGS="%s"' % ' '.join(CPPFLAGS))
         env_lines.append('export LDFLAGS="%s"' % ' '.join(LDFLAGS))
 
-    return ['('] + env_lines + conf_lines + [')']
+    return setup_lines + ['('] + env_lines + conf_lines + [')']

--- a/pkgs/dolfin/dolfin.yaml
+++ b/pkgs/dolfin/dolfin.yaml
@@ -24,7 +24,7 @@ defaults:
 
 build_stages: 
 - name: set_python_version
-  after: setup_builddir
+  after: prologue
   handler: bash
   bash: |
     export PYVER={{pyver}}

--- a/pkgs/dolfin/dolfin.yaml
+++ b/pkgs/dolfin/dolfin.yaml
@@ -25,6 +25,7 @@ defaults:
 build_stages: 
 - name: set_python_version
   after: prologue
+  before: configure
   handler: bash
   bash: |
     export PYVER={{pyver}}

--- a/pkgs/exodus/exodus.yaml
+++ b/pkgs/exodus/exodus.yaml
@@ -23,7 +23,6 @@ build_stages:
 
 - name: switch_dir
   after: prologue
-  before: setup_builddir
   handler: bash
   bash: |
     cd exodus

--- a/pkgs/lapack.yaml
+++ b/pkgs/lapack.yaml
@@ -30,10 +30,6 @@ build_stages:
               ]
   build_in_source: true
 
-- name: setup_builddir
-  mode: override
-  bash: |
-
 when_build_dependency:
 - {set: 'LAPACK_LDFLAGS', value: '-Wl,-rpath,${ARTIFACT}/lib -L${ARTIFACT}/lib -llapack'}
 - {set: 'BLAS_LDFLAGS', value: '-Wl,-rpath,${ARTIFACT}/lib -L${ARTIFACT}/lib -lblas'}

--- a/pkgs/scalapack.yaml
+++ b/pkgs/scalapack.yaml
@@ -1,3 +1,4 @@
+
 extends: [cmake_package]
 
 dependencies:
@@ -28,6 +29,3 @@ build_stages:
               ]
   build_in_source: true
 
-- name: setup_builddir
-  mode: override
-  bash: |

--- a/pkgs/vtk/vtk.yaml
+++ b/pkgs/vtk/vtk.yaml
@@ -22,7 +22,6 @@ build_stages:
 
 - name: setup_dirs
   after: prologue
-  before: setup_builddir
   handler: bash
   bash: |
     export PYTHONPATH=${ARTIFACT}/{{python_site_packages_rel}}:$PYTHONPATH
@@ -31,7 +30,6 @@ build_stages:
 - name: glx_glext_legacy_patch
   files: [GLX_GLEXT_LEGACY.patch]
   handler: bash
-  before: setup_builddir
   bash: |
     patch -p1 < _hashdist/GLX_GLEXT_LEGACY.patch
 
@@ -39,7 +37,6 @@ build_stages:
   files: [vtk-5.10.1-cygwin.patch]
   name: vtk_cygwin_patch
   handler: bash
-  before: setup_builddir
   bash: |
     patch -p1 < _hashdist/vtk-5.10.1-cygwin.patch
 
@@ -47,7 +44,6 @@ build_stages:
   files: [vtk-disable-gc.patch]
   name: vtk_disable_gc_patch
   handler: bash
-  before: setup_builddir
   bash: |
     patch -p1 < _hashdist/vtk-disable-gc.patch
 


### PR DESCRIPTION
This Armadillo package:

```
build_stages:

  - name: configure
    build_in_source: true
```

produces the following build script:

```
set -e
export HDIST_IN_BUILD=yes
export MACOSX_DEPLOYMENT_TARGET=$(sw_vers -productVersion | sed -E "s/([0-9]+\.[0-9]+).*/\1/")

(
export CPPFLAGS="-I${CMAKE_DIR}/include"
export LDFLAGS="-L${CMAKE_DIR}/lib "
${CMAKE} -DCMAKE_INSTALL_PREFIX:PATH="${ARTIFACT}" \
  -DCMAKE_POSITION_INDEPENDENT_CODE:BOOL=ON \
  -DCMAKE_INSTALL_RPATH:STRING="${ARTIFACT}/lib" \
  -DCMAKE_INSTALL_RPATH_USE_LINK_PATH:BOOL=ON \
  -DCMAKE_BUILD_TYPE:STRING=Release \
  -DCMAKE_PREFIX_PATH="${CMAKE_DIR}" \
  .
)
${CMAKE} --build . -- -j ${HASHDIST_CPU_COUNT}
make install
```

while this version of the package:

```
build_stages:

  - name: configure
    build_in_source: false
```

generates:

```
set -e
export HDIST_IN_BUILD=yes
export MACOSX_DEPLOYMENT_TARGET=$(sw_vers -productVersion | sed -E "s/([0-9]+\.[0-9]+).*/\1/")
mkdir -p _build && cd _build
(
export CPPFLAGS="-I${CMAKE_DIR}/include"
export LDFLAGS="-L${CMAKE_DIR}/lib "
${CMAKE} -DCMAKE_INSTALL_PREFIX:PATH="${ARTIFACT}" \
  -DCMAKE_POSITION_INDEPENDENT_CODE:BOOL=ON \
  -DCMAKE_INSTALL_RPATH:STRING="${ARTIFACT}/lib" \
  -DCMAKE_INSTALL_RPATH_USE_LINK_PATH:BOOL=ON \
  -DCMAKE_BUILD_TYPE:STRING=Release \
  -DCMAKE_PREFIX_PATH="${CMAKE_DIR}" \
  ..
)
${CMAKE} --build . -- -j ${HASHDIST_CPU_COUNT}
make install
```