### PR TITLE
suitesparse: fix broken url

### DIFF
--- a/pkgs/suitesparse.yaml
+++ b/pkgs/suitesparse.yaml
@@ -4,7 +4,7 @@ dependencies:
   run: [blas]
 
 sources:
-  - url: http://www.cise.ufl.edu/research/sparse/SuiteSparse/SuiteSparse-4.0.2.tar.gz
+  - url: http://faculty.cse.tamu.edu/davis/SuiteSparse/SuiteSparse-4.0.2.tar.gz
     key: tar.gz:so2zfcmh7yaqqcft7x7t47w66qx3fwgp
 
 build_stages:


### PR DESCRIPTION
The url for suitesparse was broken. This PR fixes this.