### PR TITLE
boost: auto detect address-model

### DIFF
--- a/pkgs/boost/boost.yaml
+++ b/pkgs/boost/boost.yaml
@@ -49,6 +49,15 @@ build_stages:
   bash: |
     patch -p2 < _hashdist/boost_1_55_fix_warnings.patch
 
+- name: set-address_model
+  before: bjam
+  handler: bash
+  bash: |
+    address_model={{address_model}}
+    if [ -z ${address_model} ]; then
+        address_model=$(getconf LONG_BIT)
+    fi
+
 - name: bjam
   after: bootstrap
   handler: bash
@@ -57,7 +66,7 @@ build_stages:
       echo "using mpi ;" > user-config.jam
       ./bjam -q \
              toolset={{toolset}} \
-             address-model={{address_model}} \
+             address-model=${address_model} \
              -j ${HASHDIST_CPU_COUNT} \
              --user-config=user-config.jam \
              --build-dir=_build\
@@ -75,7 +84,7 @@ build_stages:
     bash: |
       ./bjam -q \
              toolset={{toolset}} \
-             address-model={{address_model}} \
+             address-model=${address_model} \
              -j ${HASHDIST_CPU_COUNT} \
              --without-context \
              --without-coroutine \


### PR DESCRIPTION
This PR adds auto detection of the address-model (32/64 bits) for Boost. The old parameter `address_model` will override the auto detection (maybe needed for cross compilation). 