### PR TITLE
Update scikit-learn to 0.16.1

### DIFF
--- a/pkgs/scikit-learn.yaml
+++ b/pkgs/scikit-learn.yaml
@@ -4,5 +4,5 @@ dependencies:
   run: [numpy, scipy]
 
 sources:
-  - url: https://pypi.python.org/packages/source/s/scikit-learn/scikit-learn-0.14.1.tar.gz
-    key: tar.gz:gsbbxd2gbpnxvouoxcbdko5mxuawog73
+- key: tar.gz:ybzb4kkqk3evy4ac4blsn4v5e4nhsi7i
+  url: https://pypi.python.org/packages/source/s/scikit-learn/scikit-learn-0.16.1.tar.gz


### PR DESCRIPTION
Now one can execute SciPy tutorials notebooks (https://github.com/amueller/scipy_2015_sklearn_tutorial).