### PR TITLE
add proteus.tamucluster.yaml to stack/examples 

### DIFF
--- a/examples/proteus.tamucluster.yaml
+++ b/examples/proteus.tamucluster.yaml
@@ -1,0 +1,72 @@
+# This profile file controls your <#> (HashDist) build environment.
+
+# This profile is written specific to the user srobertp.
+# The parameters: section must be edited to reflect the 
+# desired cmake and mpi to be used.  Since each user only
+# has acces to their /u/name/ and /w/name/ accounts, you
+# must change it to reflect your own personal account name.
+
+# In the future, we'll provide better incorporation of
+# automatic environment detection.  For now, have a look
+# at the YAML files in the top-level directory and choose
+# the most *specific* file that matches your environment.
+
+extends:
+- file: linux2.yaml
+
+# The packages list specifies all the packages that you
+# require installed.  <#> will ensure that all packages
+# and their dependencies are installed when you build this
+# profile.
+
+parameters:
+  HOST_MPICC: /apps/openmpi/1.6.5/bin/mpicc
+  HOST_MPICXX: /apps/openmpi/1.6.5/bin/mpicxx
+  HOST_MPIF77: /apps/openmpi/1.6.5/bin/mpif77
+  HOST_MPIF90: /apps/openmpi/1.6.5/bin/mpif90
+  HOST_MPIEXEC: /apps/openmpi/1.6.5/bin/mpiexec
+  HOST_CMAKE: /w/srobertp/software/cmake-2.8.11.2/bin/cmake
+  PATH: |
+    /usr/bin:/bin:/usr/sbin:/sbin
+
+
+packages:
+  launcher:
+  cmake:
+    use: host-cmake
+  python:
+    host: false
+    link: shared
+    build_with: |
+      bzip2, sqlite
+  blas:
+  daetk:
+  mpi:
+    use: host-mpi
+  mpi4py:
+  nose:
+  hdf5:
+  ipython:
+  # matplotlib:
+  petsc:
+    build_with: |
+      parmetis
+    download: |
+      superlu, superlu_dist, spooles, hypre, blacs, scalapack, mumps
+    coptflags: -O2
+    link: shared
+    debug: false
+  petsc4py:
+    with_conf: true
+  pillow:
+  pytables:
+  sphinx:
+  superlu:
+  sympy:
+  tetgen:
+  triangle:
+  memory_profiler:
+  ipdb:
+  pip:
+  h5py:
+

--- a/examples/proteus.tamucluster.yaml
+++ b/examples/proteus.tamucluster.yaml
@@ -25,7 +25,6 @@ parameters:
   HOST_MPIF77: /apps/openmpi/1.6.5/bin/mpif77
   HOST_MPIF90: /apps/openmpi/1.6.5/bin/mpif90
   HOST_MPIEXEC: /apps/openmpi/1.6.5/bin/mpiexec
-  HOST_CMAKE: /w/srobertp/software/cmake-2.8.11.2/bin/cmake
   PATH: |
     /usr/bin:/bin:/usr/sbin:/sbin
 
@@ -33,7 +32,6 @@ parameters:
 packages:
   launcher:
   cmake:
-    use: host-cmake
   python:
     host: false
     link: shared


### PR DESCRIPTION
which gives a stack profile for users who wish to build on the numerical analysis Mathematics clusters located at texas a&m university.