### PR TITLE
Update pexpect.yaml

### DIFF
--- a/pkgs/pexpect.yaml
+++ b/pkgs/pexpect.yaml
@@ -1,5 +1,5 @@
 extends: [setuptools_package]
 
 sources:
-- key: zip:lrupabyl3nnmb7kdcric42o77blww42n
+- key: zip:4bpxtrpj4y6k7gr7yunxvgtlpdbrnxqc
   url: https://github.com/pexpect/pexpect/archive/3.3.zip


### PR DESCRIPTION
Key changed for some strange reason. Other builds seem to be progressing smoothly without these changes, but the build on my system won't work without them.