### PR TITLE
aioeventlet: Initial add of aioeventlet package and trollius (asyncio)

### DIFF
--- a/pkgs/aioeventlet.yaml
+++ b/pkgs/aioeventlet.yaml
@@ -1,0 +1,9 @@
+extends: [setuptools_package]
+
+dependencies:
+  build: [trollius, eventlet]
+  run: [trollius, eventlet]
+
+sources:
+ - key: tar.gz:7z4mfmrhzydxwfmb4kxcyby7guirdueh
+   url: https://pypi.python.org/packages/source/a/aioeventlet/aioeventlet-0.4.tar.gz

--- a/pkgs/eventlet.yaml
+++ b/pkgs/eventlet.yaml
@@ -1,0 +1,9 @@
+extends: [setuptools_package]
+
+dependencies:
+  build: [libevent]
+  run: []
+
+sources:
+ - key: tar.gz:q4q6s4kov74nedzea7qnhkaanhnwwv6j
+   url: https://pypi.python.org/packages/source/e/eventlet/eventlet-0.17.4.tar.gz

--- a/pkgs/libevent.yaml
+++ b/pkgs/libevent.yaml
@@ -1,0 +1,9 @@
+extends: [autotools_package]
+
+dependencies:
+  build: []
+  run: []
+
+sources:
+ - key: tar.gz:ohbmjhyk3lnm7w7ggmvdolbyz6oiw6ev
+   url: https://sourceforge.net/projects/levent/files/libevent/libevent-2.0/libevent-2.0.22-stable.tar.gz

--- a/pkgs/trollius.yaml
+++ b/pkgs/trollius.yaml
@@ -1,0 +1,9 @@
+extends: [setuptools_package]
+
+dependencies:
+  build: []
+  run: []
+
+sources:
+ - key: tar.gz:vdqofu5dde56hyhrcmst6qlhluthtur4
+   url: https://pypi.python.org/packages/source/t/trollius/trollius-2.0.tar.gz


### PR DESCRIPTION
Trollius is a 'backport' of asyncio to python2 and aioeventlet is a library that uses this.