### PR TITLE
updating  Cray XE6 configs

### DIFF
--- a/examples/proteus.garnet.gnu.yaml
+++ b/examples/proteus.garnet.gnu.yaml
@@ -67,7 +67,9 @@ packages:
   scipy:
   netcdf4f:
   python-netcdf4:
- # ode:
- # pyode:
+  ipdb:
+  pip:
+  h5py:
+  ode:
  # vtk:
  # pyvtk:

--- a/pkgs/numpy/numpy.yaml
+++ b/pkgs/numpy/numpy.yaml
@@ -39,7 +39,7 @@ build_stages:
       cat > site.cfg << EOF
       [DEFAULT]
       library_dirs = ${ACML_DIR}/gfortran64/lib
-      libraries = acml
+      libraries = acml, gfortran
       EOF
 
   - when: machine == 'CrayXE6'
@@ -48,7 +48,7 @@ build_stages:
     before: install
     handler: bash
     bash: |
-      export LDFLAGS="-shared -Wl,-rpath=${PYTHON_DIR}/lib -Wl,-rpath=${ACML_DIR}/gfortran64/lib $(${PYTHON_DIR}/bin/python-config --ldflags)"
+      export LDFLAGS="-shared -Wl,-rpath=${PYTHON_DIR}/lib -Wl,-rpath=${ACML_DIR}/gfortran64/lib $(${PYTHON_DIR}/bin/python-config --ldflags -lgfortran)"
       export LAPACK=acml
       export BLAS=acml
       export ATLAS=None


### PR DESCRIPTION
updates the base proteus stack and fixes a missing symbol error at runtime for numpy in a backward compatible way. 