### PR TITLE
updated versions and url's to github, enabled core and  image

### DIFF
--- a/pkgs/cgal.yaml
+++ b/pkgs/cgal.yaml
@@ -3,8 +3,8 @@ dependencies:
   build: [zlib, boost, gmp, mpfr]
 
 sources:
-- url: https://gforge.inria.fr/frs/download.php/32360/CGAL-4.2.tar.bz2
-  key: tar.bz2:67wy5ys57vr4ba36wltoptr3cbhflpad
+- key: tar.gz:4tvxmvt432ec6grz63evantnmvx4rqfl
+  url: https://gforge.inria.fr/frs/download.php/file/34512/CGAL-4.5.2.tar.gz
 
 defaults:
   # lib/CGAL/CGALConfig.cmake contains hard-coded path
@@ -13,8 +13,8 @@ defaults:
 build_stages:
 - name: configure
   extra: ['-D BUILD_SHARED_LIBS:BOOL=ON',
-          '-D WITH_CGAL_Core:BOOL=OFF',
-          '-D WITH_CGAL_ImageIO:BOOL=OFF',
+          '-D WITH_CGAL_Core:BOOL=ON',
+          '-D WITH_CGAL_ImageIO:BOOL=ON',
           '-D WITH_CGAL_Qt3:BOOL=OFF',
           '-D WITH_CGAL_Qt4:BOOL=OFF',
           '-D ZLIB_ROOT:PATH=${ZLIB_DIR}',

--- a/pkgs/pycgal.yaml
+++ b/pkgs/pycgal.yaml
@@ -4,8 +4,8 @@ dependencies:
   build: [cgal,python,swig]
 
 sources:
-- key: git:c1309859d56a3a4583b6ae2570e5a00dfcdc3035
-  url: http://code.google.com/p/cgal-bindings
+- key: git:28817d133f4a7d64c7048fefde6ba7fd2bda1ad4
+  url: https://github.com/CGAL/cgal-swig-bindings.git
 
 build_stages:
 - name: setup_dirs
@@ -17,7 +17,7 @@ build_stages:
 - name: configure
   extra: ['-DBUILD_PYTHON:BOOL=ON',
           '-DBUILD_JAVA:BOOL=OFF',
-          '-DCGAL_DIR:PATH=${CGAL_DIR}',
+          '-DCGAL_DIR:PATH=${CGAL_DIR}/lib/CGAL',
           '-DPYTHON_OUTDIR_PREFIX:PATH=${ARTIFACT}/{{python_site_packages_rel}}']
 - name: install
   mode: replace


### PR DESCRIPTION
@johannesring I'm putting this up in case it is of use.  I don't use cgal much, and dolfin is the only other stack I know that  might use  it.  It's basically just an update to a more recent version of cgal and a reflection of the switch from google code to  github for the python bindings hosting.