### PR TITLE
python: update to 2.7.10

### DIFF
--- a/pkgs/python/python.yaml
+++ b/pkgs/python/python.yaml
@@ -2,8 +2,8 @@ extends: [autotools_package]
 
 when pyver == '2.7':
     sources:
-    - key: tar.gz:zc52gptgvqzadwv5yvlpb2t47zvmcgkg
-      url: http://python.org/ftp/python/2.7.9/Python-2.7.9.tgz
+    - key: tar.gz:5wum43xmaptutenlwu4ec4hhyzp425jc
+      url: http://python.org/ftp/python/2.7.10/Python-2.7.10.tgz
 when pyver == '3.2':
     sources:
     - key: tar.gz:7qpecklofhkhn5uwga5mvyutvz5cgehq


### PR DESCRIPTION
This is a periodic update.

2.7.10 built cleanly for me and the dependencies that I use.