### PR TITLE
updated petsc4py and  daetk to work with petsc v3.6.1

### DIFF
--- a/pkgs/daetk/arch.cygwin
+++ b/pkgs/daetk/arch.cygwin
@@ -1,4 +1,4 @@
-include ${PETSC}/conf/variables
+include ${PETSC}/lib/petsc/conf/variables
 PREFIX=${ARTIFACT}
 ARCHIVE_SUFFIX = .dll
 

--- a/pkgs/daetk/arch.darwin
+++ b/pkgs/daetk/arch.darwin
@@ -1,4 +1,4 @@
-include ${PETSC}/conf/variables
+include ${PETSC}/lib/petsc/conf/variables
 PREFIX=${ARTIFACT}
 ARCHIVE_SUFFIX = .dylib
 

--- a/pkgs/daetk/arch.linux
+++ b/pkgs/daetk/arch.linux
@@ -1,4 +1,4 @@
-include ${PETSC}/conf/variables
+include ${PETSC}/lib/petsc/conf/variables
 PREFIX=${ARTIFACT}
 ARCHIVE_SUFFIX = .so
 

--- a/pkgs/daetk/daetk.yaml
+++ b/pkgs/daetk/daetk.yaml
@@ -6,7 +6,7 @@ dependencies:
 
 sources:
 - url: https://github.com/erdc-cm/daetk.git
-  key: git:48b9fefce28c7b4c0a6b10e417c5b385914f6d9d
+  key: git:e05b9975a2d413148ce122a274be675b27f9450d
 
 build_stages:
 - when: platform == 'Darwin'

--- a/pkgs/petsc4py/petsc4py.yaml
+++ b/pkgs/petsc4py/petsc4py.yaml
@@ -24,6 +24,14 @@ build_stages:
     bash: |
       patch -up1 < _hashdist/petsc4py_install_conf.patch
 
+  - when: version == '3.6.0'
+    name: with_conf
+    handler: bash
+    files: [petsc4py_install_conf_3.6.0.patch]
+    before: install
+    bash: |
+      patch -up1 < _hashdist/petsc4py_install_conf_3.6.0.patch
+
   - when: platform == 'Cygwin'
     name: explicit_build
     after: fix_libpetsc4py_decls_detection

--- a/pkgs/petsc4py/petsc4py_install_conf_3.6.0.patch
+++ b/pkgs/petsc4py/petsc4py_install_conf_3.6.0.patch
@@ -1,0 +1,34 @@
+diff --git a/conf/petscconf.py b/conf/petscconf.py
+index 8cd322c..65337b3 100644
+--- a/conf/petscconf.py
++++ b/conf/petscconf.py
+@@ -14,8 +14,8 @@ __all__ = ['setup',
+ 
+ # --------------------------------------------------------------------
+ 
+-from conf.baseconf import setup, Extension
+-from conf.baseconf import config, build, build_src, build_ext, install
+-from conf.baseconf import clean, test, sdist
++from .baseconf import setup, Extension
++from .baseconf import config, build, build_src, build_ext, install
++from .baseconf import clean, test, sdist
+ 
+ # --------------------------------------------------------------------
+diff --git a/setup.py b/setup.py
+index 381d006..369e9b1 100755
+--- a/setup.py
++++ b/setup.py
+@@ -114,9 +114,11 @@ def run_setup():
+             setup_args['setup_requires'] = ['Cython>='+CYTHON]
+     #
+     setup(packages     = ['petsc4py',
+-                          'petsc4py.lib',],
++                          'petsc4py.lib',
++                          'petsc4py.conf'],
+           package_dir  = {'petsc4py'     : 'src',
+-                          'petsc4py.lib' : 'src/lib'},
++                          'petsc4py.lib' : 'src/lib',
++                          'petsc4py.conf': 'conf'},
+           package_data = {'petsc4py'     : ['include/petsc4py/*.h',
+                                             'include/petsc4py/*.i',
+                                             'include/petsc4py/*.pxd',

--- a/pkgs/proteus.yaml
+++ b/pkgs/proteus.yaml
@@ -4,7 +4,7 @@ dependencies:
   run: [daetk, ipython, matplotlib, nose, mpi4py, petsc4py, pytables, sphinx, superlu, sympy, tetgen, triangle]
 
 sources:
-  - key: git:3d2bebca095ae8ac8baffde4c066c03590565510
+  - key: git:1806eeddee64277b48cfbc79155752b2617e53f8
     url: https://github.com/erdc-cm/proteus
 
 # Proteus is a namespace package, do *not* link the Proteus directory itself in.


### PR DESCRIPTION
@johannesring I tested the petsc 3.6.1 version you added, and it is working fine for me. This PR has some of the changes petsc4py and daetk that  I ended up making to run proteus with the new version.