### PR TITLE
Update to Ruby-2.2.3

### DIFF
--- a/pkgs/ruby.yaml
+++ b/pkgs/ruby.yaml
@@ -4,8 +4,8 @@ dependencies:
   run: [curl, zlib, openssl, libyaml, libxml2, libxslt, libiconv, ncurses, readline]
 
 sources:
-- key: tar.bz2:g3hhf6ck4qjj63ggnyzqo6tz3b5qddvh
-  url: http://cache.ruby-lang.org/pub/ruby/2.1/ruby-2.1.3.tar.bz2
+- key: tar.gz:354v6l4zqyduljawbeveabfqc3gpo7ul
+  url: https://cache.ruby-lang.org/pub/ruby/2.2/ruby-2.2.3.tar.gz
 
 defaults:
   # /bin/ruby contains hard-coded path
@@ -13,7 +13,7 @@ defaults:
 
 profile_links:
   - name: gem_binaries
-    link: 'lib/ruby/gems/2.1.0/**/bin/*'
+    link: 'lib/ruby/gems/2.2.0/**/bin/*'
 
 build_stages:
   - name: test_modules


### PR DESCRIPTION
This fixes a bug in ruby where it couldn't connect to its own server
due to a SSL/TLS incompatibility:

$ hit develop
$ ./default/bin/gem --install-dir ./default install bundler
ERROR:  Could not find a valid gem 'bundler' (>= 0), here is why:
          Unable to download data from https://rubygems.org/ - SSL_connect returned=1 errno=0 state=error: certificate verify failed (https://api.rubygems.org/latest_specs.4.8.gz)

See also: https://github.com/rubygems/rubygems/issues/665