### PR TITLE
Enable shared library support in Ruby to work around OSX build failure

### DIFF
--- a/pkgs/ruby.yaml
+++ b/pkgs/ruby.yaml
@@ -16,6 +16,10 @@ profile_links:
     link: 'lib/ruby/gems/2.2.0/**/bin/*'
 
 build_stages:
+  - name: configure
+    mode: override
+    extra: ['--enable-shared']
+
   - name: test_modules
     after: install
     handler: bash


### PR DESCRIPTION
Without this I can't build ruby on OSX, it fails with:
~~~~
[...]
compiling ./enc/encdb.c
linking encoding encdb.bundle
ld: warning: directory not found for option '-L/usr/local/lib'
Undefined symbols for architecture x86_64:
  "_rb_enc_set_base", referenced from:
      _Init_encdb in encdb.o
  "_rb_enc_set_dummy", referenced from:
      _Init_encdb in encdb.o
  "_rb_encdb_alias", referenced from:
      _Init_encdb in encdb.o
  "_rb_encdb_declare", referenced from:
      _Init_encdb in encdb.o
  "_rb_encdb_dummy", referenced from:
      _Init_encdb in encdb.o
  "_rb_encdb_replicate", referenced from:
      _Init_encdb in encdb.o
  "_rb_encdb_set_unicode", referenced from:
      _Init_encdb in encdb.o
ld: symbol(s) not found for architecture x86_64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
make[1]: *** [.ext/x86_64-darwin14/enc/encdb.bundle] Error 1
make: *** [enc] Error 2
~~~~
Also why wouldn't you want a shared library in the first place?