### PR TITLE
rpath fixes for os x

### DIFF
--- a/pkgs/boost/boost.yaml
+++ b/pkgs/boost/boost.yaml
@@ -117,7 +117,7 @@ build_stages:
   handler: bash
   bash: |
     for boostlib in ${ARTIFACT}/lib/libboost_*.dylib; do
-        install_name_tool -add_rpath ${ARTIFACT}/lib/ ${boostlib}
+        install_name_tool -add_rpath @loader_path ${boostlib}
         install_name_tool -id @rpath/$(basename ${boostlib}) ${boostlib}
         otool -L ${boostlib} | while read line; do
             set +e  # do not fail on grep below

--- a/pkgs/boost/boost.yaml
+++ b/pkgs/boost/boost.yaml
@@ -111,6 +111,24 @@ build_stages:
         ${PATCHELF} --set-rpath ${ARTIFACT}/lib:${BZIP2_DIR}/lib:${ZLIB_DIR}/lib ${lib}
     done
 
+- when: platform == 'Darwin'
+  name: rpath_fix
+  after: bjam
+  handler: bash
+  bash: |
+    for boostlib in ${ARTIFACT}/lib/libboost_*.dylib; do
+        install_name_tool -add_rpath ${ARTIFACT}/lib/ ${boostlib}
+        install_name_tool -id @rpath/$(basename ${boostlib}) ${boostlib}
+        otool -L ${boostlib} | while read line; do
+            set +e  # do not fail on grep below
+            lib=$(echo $line | sed 's/\(libboost_.*\.dylib\).*/\1/' | grep ^libboost_)
+            set -e
+            if [ ! -z ${lib} ]; then
+                install_name_tool -change ${lib} @rpath/${lib} ${boostlib}
+            fi
+        done
+    done
+
 when_build_dependency:
 - set: BOOST_MULTITHREADED
   value: "OFF"

--- a/pkgs/dolfin/dolfin.py
+++ b/pkgs/dolfin/dolfin.py
@@ -52,6 +52,9 @@ def configure(ctx, stage_args):
         LDFLAGS.append(rpath_flag(ctx, '${%s_DIR}/lib' % dep_var))
     conf_lines.append('-D CMAKE_PREFIX_PATH="%s"' % ';'.join(prefix_paths))
 
+    if ctx.parameters['platform'] == 'Darwin':
+        conf_lines.append('-D CMAKE_MACOSX_RPATH:BOOL=ON')
+
     if ctx.parameters['platform'] == 'Cygwin':
         libxml2 = '${LIBXML2_DIR}/lib/libxml2.dll.a'
         conf_lines.append('-D LIBXML2_LIBRARIES:FILEPATH="%s"' % libxml2)

--- a/pkgs/mshr.yaml
+++ b/pkgs/mshr.yaml
@@ -14,4 +14,5 @@ defaults:
 build_stages:
 - name: configure
   extra: ['-D BUILD_SHARED_LIBS:BOOL=ON',
-          '-D BOOST_ROOT:PATH="${BOOST_DIR}"']
+          '-D BOOST_ROOT:PATH="${BOOST_DIR}"',
+          '-D CMAKE_MACOSX_RPATH:BOOL=ON']

--- a/pkgs/vtk/vtk.yaml
+++ b/pkgs/vtk/vtk.yaml
@@ -83,6 +83,25 @@ build_stages:
         ${PATCHELF} --set-rpath ${ARTIFACT}/lib/vtk-5.10 ${lib}
     done
 
+- when: platform == 'Darwin'
+  name: rpath_fix
+  after: install
+  handler: bash
+  bash: |
+    for vtklib in ${ARTIFACT}/lib/vtk-5.10/*.dylib; do
+        if [ ! -L ${vtklib} ]; then
+            install_name_tool -id @rpath/$(basename ${vtklib}) ${vtklib}
+            otool -L ${vtklib} | while read line; do
+                set +e
+                lib=$(echo $line | sed 's/\(lib.*\.dylib\).*/\1/' | grep ^lib)
+                set -e
+                if [ ! -z ${lib} ]; then
+                    install_name_tool -change ${lib} @rpath/${lib} ${vtklib}
+                fi
+            done
+        fi
+    done
+
 profile_links:
 - name: python_packages
   link: 'lib/python{{pyver}}/site-packages/*'


### PR DESCRIPTION
In the latest version of OS X (10.11), setting `DYLD_LIBRARY_PATH` and `DYLD_FALLBACK_LIBRARY_PATH` does not work as in earlier versions of OS X. Using rpath is therefore important. This PR fixes this problem for the FEniCS stack (#593). 