### PR TITLE
fix typo on openblas yaml causing unbounded parallel make

### DIFF
--- a/pkgs/openblas.yaml
+++ b/pkgs/openblas.yaml
@@ -31,7 +31,7 @@ build_stages:
   after: prologue
   handler: bash
   bash: |
-    make USE_THREAD=${USE_THREAD} {{extra_flags}} -j${HASDIST_CPU_COUNT}
+    make USE_THREAD=${USE_THREAD} {{extra_flags}} -j${HASHDIST_CPU_COUNT}
     make {{extra_flags}} PREFIX=${ARTIFACT} install
 
 when_build_dependency:


### PR DESCRIPTION
@mbareford and @tridelat, I think this should fix the archer build on login nodes. closes #867 
