### PR TITLE
Initial add of tmux

### DIFF
--- a/pkgs/tmux.yaml
+++ b/pkgs/tmux.yaml
@@ -1,0 +1,10 @@
+extends: [autotools_package]
+
+dependencies:
+  build: [libevent, ncurses]
+
+sources:
+- key: tar.gz:gfle467uxtxs335tzm2ltzmwxvb2he34
+  url: https://github.com/tmux/tmux/releases/download/2.1/tmux-2.1.tar.gz
+
+  


### PR DESCRIPTION
Depends on ncurses and libevent
~~~~
$ ldd default/bin/tmux
	linux-vdso.so.1 (0x00007ffe11b17000)
	libutil.so.1 => /lib64/libutil.so.1 (0x00007fb162df3000)
	libtinfo.so.5 => /home/vbraun/Code/HashDist/hashstack/default/bin/../../../ncurses/rrad4h2o6kbn/lib/libtinfo.so.5 (0x00007fb162bc9000)
	libevent-2.0.so.5 => /home/vbraun/Code/HashDist/hashstack/default/bin/../../../libevent/e7tw4jpegglw/lib/libevent-2.0.so.5 (0x00007fb162981000)
	libresolv.so.2 => /lib64/libresolv.so.2 (0x00007fb162766000)
	libc.so.6 => /lib64/libc.so.6 (0x00007fb1623a4000)
	libpthread.so.0 => /lib64/libpthread.so.0 (0x00007fb162187000)
	/lib64/ld-linux-x86-64.so.2 (0x0000563e4d5bd000)
~~~~