### PR TITLE
Better workaround for Fabric

### DIFF
--- a/pkgs/fabric.yaml
+++ b/pkgs/fabric.yaml
@@ -16,11 +16,8 @@ build_stages:
 #
 # The following step works around the above error
 
-- name: install
-  after: setup_dirs
+- name: fix_install
+  after: install
   handler: bash
   bash: |
-    # build
-    $PYTHON setup.py build
-    # install
-    $PYTHON setup.py install --prefix=$ARTIFACT
+    rm -r $ARTIFACT/{{python_site_packages_rel}}/tests


### PR DESCRIPTION
The problem is that the default install creates the following directory
structure in lib/python2.7/site-packages:

fabfile  fabric  Fabric-1.10.2-py2.7.egg-info  tests

The previous workaround created this structure:

Fabric-1.10.2-py2.7.egg  site.py  site.pyc

Which causes the 'fabric' module not to be found in Hashdist. The new
workaround creates the following structure:

fabfile  fabric  Fabric-1.10.2-py2.7.egg-info

Now everything works as expected.