### PR TITLE
Do not link the site-packages/__pycache__ directory

### DIFF
--- a/pkgs/python/python.yaml
+++ b/pkgs/python/python.yaml
@@ -199,5 +199,8 @@ profile_links:
   - name: python_exclude
     after: python_packages
     before: everything
-
     exclude: 'lib/python{{pyver}}/site-packages/**/*'
+
+  - name: exclude_python3_cache
+    before: python_exclude
+    link: 'lib/python{{pyver}}/site-packages/__pycache__/*'


### PR DESCRIPTION
Otherwise, "hit develop" builds with python3 cannot use pip since it
wants to put new files into `site-packages/__pycache__`

~~~~
$ ./default/bin/pip3 install ipython glob2 pyyaml ld jinja2
...
PermissionError: [Errno 13] Permission denied: '/home/.../site-packages/__pycache__/decorator.cpython-35.pyc'
~~~~