### PR TITLE
flufl_lock: copy missing __init__.py to correct location

### DIFF
--- a/pkgs/flufl_lock.yaml
+++ b/pkgs/flufl_lock.yaml
@@ -3,3 +3,11 @@ extends: [setuptools_package]
 sources:
  - key: tar.gz:u2jqmtif7wjagwmju2w5x2jmx2zsshar
    url: https://pypi.python.org/packages/source/f/flufl.lock/flufl.lock-2.3.1.tar.gz
+
+build_stages:
+# Fix for issue #911
+- name: copy-missing-init-file
+  after: install
+  handler: bash
+  bash: |
+    cp flufl/__init__.py ${ARTIFACT}/{{python_site_packages_rel}}/flufl/

--- a/pkgs/flufl_lock.yaml
+++ b/pkgs/flufl_lock.yaml
@@ -1,8 +1,8 @@
 extends: [setuptools_package]
 
 sources:
- - key: tar.gz:u2jqmtif7wjagwmju2w5x2jmx2zsshar
-   url: https://pypi.python.org/packages/source/f/flufl.lock/flufl.lock-2.3.1.tar.gz
+- key: tar.gz:ojrzvsr66a3zv3yslrzunmccneodiuqv
+  url: https://pypi.python.org/packages/source/f/flufl.lock/flufl.lock-2.4.1.tar.gz
 
 build_stages:
 # Fix for issue #911


### PR DESCRIPTION
This PR also updates the package to version 2.4.1, which adds support for Python 3.