### PR TITLE
Add starcluster

### DIFF
--- a/pkgs/boto.yaml
+++ b/pkgs/boto.yaml
@@ -1,0 +1,5 @@
+extends: [setuptools_package]
+
+sources:
+- key: tar.gz:sugfx43gshpzc24u5pcwph7na73eeayn
+  url: https://pypi.python.org/packages/source/b/boto/boto-2.39.0.tar.gz

--- a/pkgs/ecdsa.yaml
+++ b/pkgs/ecdsa.yaml
@@ -1,0 +1,5 @@
+extends: [setuptools_package]
+
+sources:
+- key: tar.gz:mthr5ytndtpdy46g27iqp6bv73l4niuq
+  url: https://pypi.python.org/packages/source/e/ecdsa/ecdsa-0.13.tar.gz

--- a/pkgs/iptools.yaml
+++ b/pkgs/iptools.yaml
@@ -1,0 +1,5 @@
+extends: [setuptools_package]
+
+sources:
+- key: tar.gz:b4byows35v2axjf7itpmw2tym6omvekk
+  url: https://pypi.python.org/packages/source/i/iptools/iptools-0.6.1.tar.gz

--- a/pkgs/iso8601.yaml
+++ b/pkgs/iso8601.yaml
@@ -1,0 +1,5 @@
+extends: [setuptools_package]
+
+sources:
+ - key: tar.gz:5d5vf54iqcxammzwzfhllod3dapgudgd
+   url: https://pypi.python.org/packages/source/i/iso8601/iso8601-0.1.11.tar.gz

--- a/pkgs/optcomplete.yaml
+++ b/pkgs/optcomplete.yaml
@@ -1,0 +1,5 @@
+extends: [distutils_package]
+
+sources:
+- key: tar.gz:v4restb5hqtdy6qqef23vxsn43cx7pfs
+  url: https://bitbucket.org/blais/optcomplete/get/477883477317.tar.gz

--- a/pkgs/paramiko.yaml
+++ b/pkgs/paramiko.yaml
@@ -1,7 +1,7 @@
 extends: [distutils_package]
 dependencies:
-  run: [pycrypto]
+  run: [pycrypto, ecdsa]
 
 sources:
-  - url: https://pypi.python.org/packages/source/p/paramiko/paramiko-1.10.1.tar.gz
-    key: tar.gz:l6wa3oz5osml6st6doh2zeqmxclxvehc
+- key: tar.gz:gkl6xu6na4xvon3s67due2jzurb4mlcf
+  url: https://pypi.python.org/packages/source/p/paramiko/paramiko-1.16.0.tar.gz

--- a/pkgs/python-scp.yaml
+++ b/pkgs/python-scp.yaml
@@ -1,0 +1,9 @@
+extends: [setuptools_package]
+
+dependencies:
+  build: [paramiko]
+  run: [paramiko]
+
+sources:
+ - key: tar.gz:dd2z4sg7m75mbmdjlelatihu2ugxqgqq
+   url: https://pypi.python.org/packages/source/s/scp/scp-0.10.2.tar.gz

--- a/pkgs/starcluster.yaml
+++ b/pkgs/starcluster.yaml
@@ -1,0 +1,9 @@
+extends: [setuptools_package]
+
+dependencies:
+  build: [paramiko, boto, workerpool, jinja2, decorator, iptools, optcomplete, pycrypto, python-scp, iso8601]
+  run: [paramiko, boto, workerpool, jinja2, decorator, iptools, optcomplete, pycrypto, python-scp, iso8601]
+
+sources:
+- key: tar.gz:mxpszaz5whosc2kwamy3xjr3sp365nn2
+  url: https://pypi.python.org/packages/source/S/StarCluster/StarCluster-0.95.6.tar.gz

--- a/pkgs/workerpool.yaml
+++ b/pkgs/workerpool.yaml
@@ -1,0 +1,9 @@
+extends: [setuptools_package]
+
+dependencies:
+  build: [six]
+  run: [six]
+
+sources:
+ - key: tar.gz:vncv3mg6ab3shtxejsdng7bfov2h6fmh
+   url: https://pypi.python.org/packages/source/w/workerpool/workerpool-0.9.4.tar.gz


### PR DESCRIPTION
This adds the StarCluster package and all the dependencies that were not already available in HashStack. It also updates paramiko to latest version 1.16.0 (required by StarCluster) and adds ecdsa as dependency to paramiko.