### PR TITLE
Libevent url change

### DIFF
--- a/pkgs/libevent.yaml
+++ b/pkgs/libevent.yaml
@@ -6,4 +6,5 @@ dependencies:
 
 sources:
  - key: tar.gz:ohbmjhyk3lnm7w7ggmvdolbyz6oiw6ev
-   url: https://sourceforge.net/projects/levent/files/libevent/libevent-2.0/libevent-2.0.22-stable.tar.gz
+ - url: https://github.com/libevent/libevent/releases/download/release-2.0.22-stable/libevent-2.0.22-stable.tar.gz
+


### PR DESCRIPTION
The sourceforge link changed. Also, libevent moved to github so use that.