### PR TITLE
Fix openjpeg version to 1.5

### DIFF
--- a/pkgs/openjpeg.yaml
+++ b/pkgs/openjpeg.yaml
@@ -10,8 +10,8 @@ defaults:
   relocatable: false
 
 sources:
-- key: tar.gz:cizlxakp3cgy5uyuzfhqx7v3appikwky
-  url: http://sourceforge.net/projects/openjpeg.mirror/files/2.1.0/openjpeg-2.1.0.tar.gz
+- key: tar.gz:zgii7k2eimvc5usvbrcxzn7hg3ng27bs
+  url: http://sourceforge.net/projects/openjpeg.mirror/files/openjpeg-1.5.0.tar.gz
 
 build_stages:
 

--- a/pkgs/openjpeg.yaml
+++ b/pkgs/openjpeg.yaml
@@ -1,12 +1,10 @@
 extends: [cmake_package]
 
-defaults:
-  version: '1.5'
-
 dependencies:
   build: []
 
 defaults:
+  version: 1.5
   relocatable: false
 
 when version == '1.5':
@@ -20,10 +18,10 @@ when version == '2.1':
 
 # grib_api, at least, expects not to find this namespaced
 build_stages:
-when version == '1.5':
-  - name: fix_include
-    after: install
-    handler: bash
-    bash: |
-      ln -s ${ARTIFACT}/include/openjpeg-1.5/openjpeg.h ${ARTIFACT}/include/openjpeg.h
+- when: version == '1.5'
+  name: fix_include
+  after: install
+  handler: bash
+  bash: |
+    ln -s ${ARTIFACT}/include/openjpeg-1.5/openjpeg.h ${ARTIFACT}/include/openjpeg.h
 

--- a/pkgs/openjpeg.yaml
+++ b/pkgs/openjpeg.yaml
@@ -1,7 +1,7 @@
 extends: [cmake_package]
 
-# version 1.5 of openjpeg
-# later versions should go in openjpeg2
+defaults:
+  version: '1.5'
 
 dependencies:
   build: []
@@ -9,16 +9,21 @@ dependencies:
 defaults:
   relocatable: false
 
-sources:
-- key: tar.gz:zgii7k2eimvc5usvbrcxzn7hg3ng27bs
-  url: http://sourceforge.net/projects/openjpeg.mirror/files/openjpeg-1.5.0.tar.gz
-
-build_stages:
+when version == '1.5':
+  sources:
+  - key: tar.gz:zgii7k2eimvc5usvbrcxzn7hg3ng27bs
+    url: http://sourceforge.net/projects/openjpeg.mirror/files/openjpeg-1.5.0.tar.gz
+when version == '2.1':
+  sources:
+  - key: tar.gz:cizlxakp3cgy5uyuzfhqx7v3appikwky
+    url: http://sourceforge.net/projects/openjpeg.mirror/files/2.1.0/openjpeg-2.1.0.tar.gz
 
 # grib_api, at least, expects not to find this namespaced
-- name: fix_include
-  after: install
-  handler: bash
-  bash: |
-    ln -s ${ARTIFACT}/include/openjpeg-1.5/openjpeg.h ${ARTIFACT}/include/openjpeg.h
+build_stages:
+when version == '1.5':
+  - name: fix_include
+    after: install
+    handler: bash
+    bash: |
+      ln -s ${ARTIFACT}/include/openjpeg-1.5/openjpeg.h ${ARTIFACT}/include/openjpeg.h
 


### PR DESCRIPTION
The symbolic link created by the fix_include step was hard-coded and
pointing to a different version. Also, version 2.1 was breaking grib
compilation.
