### PR TITLE
Fix possible syntax errors in openjpeg.yaml

### DIFF
--- a/pkgs/openjpeg.yaml
+++ b/pkgs/openjpeg.yaml
@@ -1,12 +1,10 @@
 extends: [cmake_package]
 
-defaults:
-  version: '1.5'
-
 dependencies:
   build: []
 
 defaults:
+  version: '1.5'
   relocatable: false
 
 when version == '1.5':
@@ -20,9 +18,9 @@ when version == '2.1':
 
 # grib_api, at least, expects not to find this namespaced
 build_stages:
-when version == '1.5':
   - name: fix_include
     after: install
+    when: version == '1.5'
     handler: bash
     bash: |
       ln -s ${ARTIFACT}/include/openjpeg-1.5/openjpeg.h ${ARTIFACT}/include/openjpeg.h


### PR DESCRIPTION
Hashdist wasn't processing the file with two default sections and with
when statement outside of fix_include section.