### PR TITLE
Configure python 3.5 without ensurepip as well

### DIFF
--- a/pkgs/python/python.yaml
+++ b/pkgs/python/python.yaml
@@ -68,7 +68,7 @@ build_stages:
     append: {LDFLAGS: "-Wl,-rpath,${ARTIFACT}/lib"}
     extra: ['--enable-shared']
 
-  - when: pyver == '3.4'
+  - when: pyver == '3.4' or pyver == '3.5'
     name: configure
     mode: update
     extra: ['--without-ensurepip']


### PR DESCRIPTION
This is necessary to build pygments as noted in #536 