### PR TITLE
Update Jupyter to the latest releases

### DIFF
--- a/pkgs/fabric.yaml
+++ b/pkgs/fabric.yaml
@@ -6,18 +6,3 @@ dependencies:
 sources:
 - key: tar.gz:mzvd3kjconjs2osj3unmkpr5oiof5qxs
   url: https://pypi.python.org/packages/source/F/Fabric/Fabric-1.10.2.tar.gz
-
-
-build_stages:
-
-# Due to this error:
-#
-# [profile|ERROR] hit command failed: [Errno 13] [Errno 13] Permission denied: '/Users/jtang/.hashdist/bld/profile/t63wczbqichu/lib/python2.7/site-packages/tests/etree13' in silent_makedirs(u'/Users/jtang/.hashdist/bld/profile/t63wczbqichu/lib/python2.7/site-packages/tests/etree13',)
-#
-# The following step works around the above error
-
-- name: fix_install
-  after: install
-  handler: bash
-  bash: |
-    rm -r $ARTIFACT/{{python_site_packages_rel}}/tests

--- a/pkgs/ipykernel.yaml
+++ b/pkgs/ipykernel.yaml
@@ -5,5 +5,5 @@ dependencies:
   run: []
 
 sources:
- - key: zip:ec43ioxiux6apa7c2pnmmhvmsjpfbo3j
-   url: https://pypi.python.org/packages/source/i/ipykernel/ipykernel-4.0.3.zip
+ - key: zip:jel6deigqeydi7lfpbwr2mpg7sfoedsz
+   url: https://pypi.python.org/packages/source/i/ipykernel/ipykernel-4.3.1.zip

--- a/pkgs/ipython.yaml
+++ b/pkgs/ipython.yaml
@@ -6,5 +6,5 @@ dependencies:
         path_py]
 
 sources:
- - key: zip:lj4uy5zujfgpqu3km7kqttyuip2oksei
-   url: https://pypi.python.org/packages/source/i/ipython/ipython-4.0.0.zip
+ - key: zip:ktkceh6azaacpi2ezizs632e4t6crenz
+   url: https://pypi.python.org/packages/source/i/ipython/ipython-4.1.1.zip

--- a/pkgs/ipython.yaml
+++ b/pkgs/ipython.yaml
@@ -1,4 +1,4 @@
-extends: [setuptools_package]
+extends: [distutils_package]
 
 dependencies:
   run: [pyzmq, tornado, jinja2, jsonschema, pygments, sphinx, pexpect,

--- a/pkgs/ipywidgets.yaml
+++ b/pkgs/ipywidgets.yaml
@@ -5,5 +5,5 @@ dependencies:
   run: []
 
 sources:
- - key: tar.gz:e4bshfiaqf7eh7vqsb5h4d3wy6nyvhgn
-   url: https://pypi.python.org/packages/source/i/ipywidgets/ipywidgets-4.0.3.tar.gz
+ - key: tar.gz:z3vtexsfvxuvg7bncfp63hksfzog5ef3
+   url: https://pypi.python.org/packages/source/i/ipywidgets/ipywidgets-4.1.1.tar.gz

--- a/pkgs/jupyter-client.yaml
+++ b/pkgs/jupyter-client.yaml
@@ -5,5 +5,5 @@ dependencies:
   run: []
 
 sources:
- - key: zip:yjhthnpahezn33fxc7fjtwx6unwvtdel
-   url: https://pypi.python.org/packages/source/j/jupyter_client/jupyter_client-4.0.0.zip
+ - key: zip:awsxibni7ukjgvqupt5f4vc333xnqw7v
+   url: https://pypi.python.org/packages/source/j/jupyter_client/jupyter_client-4.1.1.zip

--- a/pkgs/jupyter-console.yaml
+++ b/pkgs/jupyter-console.yaml
@@ -5,5 +5,5 @@ dependencies:
   run: []
 
 sources:
- - key: zip:jewvtqfsjiwar3uq2gsvbhwsa2aw3odc
-   url: https://pypi.python.org/packages/source/j/jupyter_console/jupyter_console-4.0.2.zip
+ - key: zip:iupip7dpkr7tdxuynwr3w2kb5ypppaxl
+   url: https://pypi.python.org/packages/source/j/jupyter_console/jupyter_console-4.1.1.zip

--- a/pkgs/nbformat.yaml
+++ b/pkgs/nbformat.yaml
@@ -5,5 +5,5 @@ dependencies:
   run: []
 
 sources:
- - key: zip:4fxkyjfnjezejxxhpkhu6lokr7rahjgh
-   url: https://pypi.python.org/packages/source/n/nbformat/nbformat-4.0.0.zip
+ - key: zip:3sdv5ahsufylg2iza7qequchaj65c7lw
+   url: https://pypi.python.org/packages/source/n/nbformat/nbformat-4.0.1.zip

--- a/pkgs/notebook.yaml
+++ b/pkgs/notebook.yaml
@@ -5,5 +5,5 @@ dependencies:
   run: [functools, functools32, ipython-genutils]
 
 sources:
- - key: tar.gz:lldrnfam7v3benu64f34bv74b24iqm23
-   url: https://pypi.python.org/packages/source/n/notebook/notebook-4.0.5.tgz
+ - key: tar.gz:wwlug65dgu4ceeai4ip6u4onahw2twqv
+   url: https://pypi.python.org/packages/source/n/notebook/notebook-4.1.0.tar.gz

--- a/pkgs/qtconsole.yaml
+++ b/pkgs/qtconsole.yaml
@@ -5,5 +5,5 @@ dependencies:
   run: []
 
 sources:
- - key: zip:qp2mzb5wxki36mfb4ai53j5m6uqcyyzv
-   url: https://pypi.python.org/packages/source/q/qtconsole/qtconsole-4.0.1.zip
+ - key: tar.gz:snzrj5htlppj5yuos6yzske7rla3doqu
+   url: https://pypi.python.org/packages/source/q/qtconsole/qtconsole-4.2.0.tar.gz

--- a/pkgs/setuptools.yaml
+++ b/pkgs/setuptools.yaml
@@ -18,8 +18,8 @@ build_stages:
       ${PYTHON} setup.py install --prefix=. --root=${ARTIFACT}/Python.framework/Versions/{{pyver}} --single-version-externally-managed
 
 sources:
-  - url: https://pypi.python.org/packages/source/s/setuptools/setuptools-3.4.3.tar.gz
-    key: tar.gz:yfr3o4jkjyuvq7cmwfn52gmjt7xmiopn
+- key: tar.gz:et6pyfjwjkp6bgrcb435fxhnzbexsxr5
+  url: https://pypi.python.org/packages/source/s/setuptools/setuptools-20.2.2.tar.gz
 
 when_build_dependency:
   - when: not python_framework


### PR DESCRIPTION
This depends on #849. This PR only adds the patches from 25cfd55 up.

IPython requires setuptools > 18.5, so we need to update setuptools which triggers a rebuild of everything. But things seem to work.