### PR TITLE
Bumping version of py as required by recent bump in py.test

### DIFF
--- a/pkgs/py.yaml
+++ b/pkgs/py.yaml
@@ -1,5 +1,5 @@
 extends: [setuptools_package]
 
 sources:
-  - url: https://pypi.python.org/packages/source/p/py/py-1.4.20.tar.gz
-    key: tar.gz:epez3gplwkta5nychn2xpp6jrcwlacja
+  - url: https://pypi.python.org/packages/source/p/py/py-1.4.29.tar.gz
+    key: tar.gz:e6pbc4rt6ic54hsg5q3ow772lgm7dpct


### PR DESCRIPTION
See #922 
py is a dependence of py.test and recent bump requires py to be >= 1.4.29