### PR TITLE
fftw2: supply the correct F77 compiler

### DIFF
--- a/pkgs/fftw2.yaml
+++ b/pkgs/fftw2.yaml
@@ -8,5 +8,13 @@ sources:
   key: tar.gz:7acx7lq4px4lteiwpa7ph2kknjcfddkj
 
 build_stages:
+- name: f77_fix
+  mode: replace
+  after: prologue
+  before: configure
+  handler: bash
+  bash: |
+    export F77=gfortran
+
 - name: configure
   extra: ['--enable-mpi', '--enable-sse2', '--enable-avx']


### PR DESCRIPTION
Otherwise it uses the system wide one.