### PR TITLE
Upgrade LLVM to 3.7

### DIFF
--- a/pkgs/clang.yaml
+++ b/pkgs/clang.yaml
@@ -1,18 +1,15 @@
 extends: [cmake_package]
 
 dependencies:
-  build: [llvm]
-
+  build: [llvm, libxml2, zlib]
 
 sources:
-- url: http://llvm.org/releases/3.4/clang-3.4.src.tar.gz
-  key: tar.gz:ekuxqdntxbnh6lvz5ipx63qa3ibety6r
+- key: tar.xz:k3rbmtd4filxfvpnfi7fosc76477a3ex
+  url: http://llvm.org/releases/3.7.1/cfe-3.7.1.src.tar.xz
 
 defaults:
-  # lib/libclang.so.3.4 contains hard-coded path
   relocatable: false
 
 build_stages:
 - name: configure
-  extra: ['-D CLANG_PATH_TO_LLVM_BUILD:PATH=$LLVM_DIR',
-          '-D LLVM_MAIN_SRC_DIR:PATH=$LLVM_DIR']
+  extra: ['-D LLVM_MAIN_SRC_DIR:PATH=${LLVM_DIR}']

--- a/pkgs/llvm.yaml
+++ b/pkgs/llvm.yaml
@@ -1,12 +1,11 @@
 extends: [cmake_package]
 
+dependencies:
+  build: [python]
+
 sources:
-- url: http://llvm.org/releases/3.4/llvm-3.4.src.tar.gz
-  key: tar.gz:ewswclljfreeqg43hf7cwvpuq4hei6lg
+- key: tar.xz:xz3zj3im5rbnnruczkhdkf2tlnkfkwr5
+  url: http://llvm.org/releases/3.7.1/llvm-3.7.1.src.tar.xz
 
 defaults:
   relocatable: false
-
-build_stages:
-- name: configure
-  extra: ['-D BUILD_SHARED_LIBS:BOOL=ON']


### PR DESCRIPTION
Both Julia and Numba also depend on 3.7, so this is a good change to do. We don't have a package for Numba yet, and Julia would need more work anyway, so in this PR I just update LLVM and Clang.