### PR TITLE
chrono: added bzip2 as explicit dependency

### DIFF
--- a/pkgs/chrono.yaml
+++ b/pkgs/chrono.yaml
@@ -9,6 +9,7 @@ defaults:
 
 dependencies:
   build:
+    - bzip2
     - python
     - irrlicht
     - zlib


### PR DESCRIPTION
@cekees I got a similar error as https://github.com/hashdist/hashstack/issues/395 when trying to build chrono on CentOS.
Making bzip2 an explicit dependency for chrono fixed it.