### PR TITLE
Add libjpeg(-turbo)

### DIFF
--- a/pkgs/host-jpeg.yaml
+++ b/pkgs/host-jpeg.yaml
@@ -1,0 +1,1 @@
+extends: [host_package]

--- a/pkgs/jpeg.yaml
+++ b/pkgs/jpeg.yaml
@@ -1,0 +1,12 @@
+extends: [autotools_package]
+dependencies:
+  build: [nasm]
+
+sources:
+- key: tar.gz:kin3luyehz5may6ogatntjm4ykvs5frw
+  url: http://downloads.sourceforge.net/project/libjpeg-turbo/1.4.2/libjpeg-turbo-1.4.2.tar.gz
+
+when_build_dependency:
+  - prepend_path: PKG_CONFIG_PATH
+    value: '${ARTIFACT}/lib/pkgconfig'
+

--- a/pkgs/nasm.yaml
+++ b/pkgs/nasm.yaml
@@ -3,3 +3,7 @@ extends: [autotools_package]
 sources:
 - key: tar.xz:zgkgpryheii4kugri5sa3cq2bksnmnwu
   url: http://www.nasm.us/pub/nasm/releasebuilds/2.11.08/nasm-2.11.08.tar.xz
+
+when_build_dependency:
+- prepend_path: PATH
+  value: '${ARTIFACT}/bin'


### PR DESCRIPTION
Libjpeg is a requirement for pillow starting with version 3

There are multiple implementations, but libjpeg-turbo seems to be popular.