### PR TITLE
update numpy yaml to support version 1.11

### DIFF
--- a/pkgs/numpy/numpy.yaml
+++ b/pkgs/numpy/numpy.yaml
@@ -1,14 +1,14 @@
-extends: [distutils_package]
+extends: [setuptools_package]
 dependencies:
-  build: [blas]
-  run: [blas]
+  build: [blas, cython]
+  run: [blas, cython]
 
 sources:
-  - key: tar.gz:zzluhi5cjpyt4a3t7lvsicyi4sgrhhtd
-    url: http://downloads.sourceforge.net/numpy/numpy-1.8.2.tar.gz
+  - key: tar.gz:5cmod4vyscjlsu2sucsygfjkdbacbjes
+    url: https://github.com/numpy/numpy/archive/v1.11.0.tar.gz
+
 
 build_stages:
-
   - when: platform == 'linux'
     name: create-site.cfg
     before: install
@@ -18,6 +18,7 @@ build_stages:
       [atlas]
       atlas_libs = openblas
       library_dirs = ${OPENBLAS_DIR}/lib
+      include_dirs = ${OPENBLAS_DIR}/include
       EOF
 
   - when: platform == 'linux'


### PR DESCRIPTION
Somewhere between numpy version 1.8 and 1.11 the dependencies changed from distutils to cython
and setuptools.

So I am not sure how this type of dependency should be handled, because now the _extends_ section of  yaml configuration file has to be changed accordingly.