### PR TITLE
patch MAX_JBUFS=24 in parmetis on OS X

### DIFF
--- a/pkgs/parmetis/clang_max_jbufs.patch
+++ b/pkgs/parmetis/clang_max_jbufs.patch
@@ -1,0 +1,12 @@
+--- parmetis-4.0.3/metis/GKlib/error.c	2016-04-29 13:21:02.000000000 +0200
++++ parmetis-4.0.3/metis/GKlib/error.c	2016-04-29 13:21:06.000000000 +0200
+@@ -18,7 +18,7 @@
+
+ /* These are the jmp_buf for the graceful exit in case of severe errors.
+    Multiple buffers are defined to allow for recursive invokation. */
+-#define MAX_JBUFS 128
++#define MAX_JBUFS 24
+ __thread int gk_cur_jbufs=-1;
+ __thread jmp_buf gk_jbufs[MAX_JBUFS];
+ __thread jmp_buf gk_jbuf;
+ 

--- a/pkgs/parmetis/parmetis.yaml
+++ b/pkgs/parmetis/parmetis.yaml
@@ -23,11 +23,14 @@ build_stages:
 
 - when: platform == 'Darwin'
   name: no_unused_but_set_variable
-  files: [no_unused_but_set_variable.patch]
+  files:
+    - no_unused_but_set_variable.patch
+    - clang_max_jbufs.patch
   before: configure
   handler: bash
   bash: |
     patch -p1 < _hashdist/no_unused_but_set_variable.patch
+    patch -p1 < _hashdist/clang_max_jbufs.patch
 
 - when: platform == 'Cygwin'
   name: fix___cdecl_redefined


### PR DESCRIPTION
clang 7.3 requires MAX_JBUFS < 25