### PR TITLE
Convert readthedocs link for their .org -> .io migration for hosted projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 HashStack is a collection of software profiles that builds on various architectures (Linux, Windows, Mac, clusters, ...) and allows optional reuse of system-wide packages (compilers, LAPACK, Python, ...).
 
 To build these profiles, you need the [hit](https://github.com/hashdist/hashdist) tool from HashDist.
-Read [hit's documentation](http://hashdist.readthedocs.org/) about how to use it.
+Read [hit's documentation](https://hashdist.readthedocs.io/) about how to use it.
 
 ## Usage
 


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.