### PR TITLE
FEniCS updates

### DIFF
--- a/base/cmake_package.py
+++ b/base/cmake_package.py
@@ -38,6 +38,9 @@ def configure(ctx, stage_args):
     if stage_args.get('empty_osx_deployment_target', False):
         conf_lines.append('-DCMAKE_OSX_DEPLOYMENT_TARGET:STRING=""')
 
+    if stage_args.get('cmake_osx_sysroot', False):
+        conf_lines.append('-DCMAKE_OSX_SYSROOT:STRING=%s' % stage_args['cmake_osx_sysroot'])
+
     #cmake needs to be given all the dependency dirs as prefix paths
     #so that we search the hashdist directories before the system directories
     #CMake doesn't use the CPPFLAGS implicitly to find libraries

--- a/base/cmake_package.yaml
+++ b/base/cmake_package.yaml
@@ -15,6 +15,8 @@ build_stages:
   - name: configure
     after: setup_builddir
     debug: {{debug}}
+    empty_osx_deployment_target: {{empty_osx_deployment_target}}
+    cmake_osx_sysroot: {{cmake_osx_sysroot}}
 
   - name: make
     after: configure

--- a/base/pip_package.yaml
+++ b/base/pip_package.yaml
@@ -1,0 +1,29 @@
+# pip_package.yaml
+# Use for installing Python packages using pip.
+
+extends: [base_package]
+
+dependencies:
+  build: [python, pip, setuptools]
+  run: [python, pip, setuptools]
+
+build_stages:
+
+- name: install
+  handler: bash
+  bash: |
+    pip install --verbose --no-deps --upgrade --prefix=${ARTIFACT} .
+
+profile_links:
+- name: python_packages
+  link: 'lib/python{{pyver}}/site-packages/*'
+  dirs: true
+
+- name: python_exclude
+  after: python_packages
+  before: everything
+  exclude: 'lib/python{{pyver}}/site-packages/**/*'
+
+when_build_dependency:
+- prepend_path: PYTHONPATH
+  value: '${ARTIFACT}/lib/python{{pyver}}/site-packages'

--- a/base/pip_package.yaml
+++ b/base/pip_package.yaml
@@ -8,8 +8,8 @@ dependencies:
   run: [python, pip, setuptools]
 
 build_stages:
-
 - name: install
+  after: prologue
   handler: bash
   bash: |
     pip install --verbose --no-deps --upgrade --prefix=${ARTIFACT} .

--- a/pkgs/cython.yaml
+++ b/pkgs/cython.yaml
@@ -1,8 +1,8 @@
 extends: [distutils_package]
 
 sources:
-- key: tar.gz:lebhjlenxupgftdz3fhlfyxuvzqm5ki2
-  url: http://cython.org/release/Cython-0.23.3.tar.gz
+- key: tar.gz:iqajqxtqrijqcfgww7vbkl7dxpgmj333
+  url: https://github.com/cython/cython/archive/0.23.3.tar.gz
 
 when_build_dependency:
   - prepend_path: PATH

--- a/pkgs/dijitso.yaml
+++ b/pkgs/dijitso.yaml
@@ -1,0 +1,8 @@
+extends: [pip_package]
+dependencies:
+  build: [mpi4py, numpy, six]
+  run: [mpi4py, numpy, six]
+
+sources:
+- key: tar.gz:amakzmnzx6kojxrgbznuf5jklopvcwsw
+  url: https://bitbucket.org/fenics-project/dijitso/downloads/dijitso-2016.1.0.tar.gz

--- a/pkgs/dolfin/dolfin.yaml
+++ b/pkgs/dolfin/dolfin.yaml
@@ -49,7 +49,10 @@ build_stages:
   after: install
   handler: bash
   bash: |
-    # FIXME: use install_name_tool to fix rpath
+    for lib in ${ARTIFACT}/lib/python{{pyver}}/site-packages/dolfin/cpp/_*.so; do
+        install_name_tool -add_rpath ${BOOST_DIR}/lib ${lib}
+        install_name_tool -add_rpath ${VTK_DIR}/lib/vtk-5.10 ${lib}
+    done
 
 - when: platform == 'Cygwin'
   name: dll_fix

--- a/pkgs/dolfin/dolfin.yaml
+++ b/pkgs/dolfin/dolfin.yaml
@@ -15,8 +15,8 @@ dependencies:
   run: [ply]
 
 sources:
-- key: tar.gz:m7vkyx7m43tr3icvtngkqqrrk346tguv
-  url: https://bitbucket.org/fenics-project/dolfin/downloads/dolfin-1.6.0.tar.gz
+- key: tar.gz:miuljvsbqknezuzbig742il2cwlke7kz
+  url: https://bitbucket.org/fenics-project/dolfin/downloads/dolfin-2016.1.0.tar.gz
 
 defaults:
   # share/dolfin/DOLFINConfig.cmake contains hard-coded path

--- a/pkgs/ffc.yaml
+++ b/pkgs/ffc.yaml
@@ -1,4 +1,4 @@
-extends: [setuptools_package]
+extends: [pip_package]
 dependencies:
   build: [fiat, instant, numpy, six, ufl, swig]
   run: [fiat, instant, numpy, six, ufl, swig]
@@ -14,3 +14,5 @@ defaults:
 when_build_dependency:
 - prepend_path: PATH
   value: '${ARTIFACT}/bin'
+- set: UFC_DIR
+  value: '${ARTIFACT}'

--- a/pkgs/ffc.yaml
+++ b/pkgs/ffc.yaml
@@ -4,8 +4,8 @@ dependencies:
   run: [fiat, instant, numpy, six, ufl, swig]
 
 sources:
-- key: tar.gz:haxhoe76owljjzpqoudlcrho5llidylj
-  url: https://bitbucket.org/fenics-project/ffc/downloads/ffc-1.6.0.tar.gz
+- key: tar.gz:kjbqzzgh2v6odoa6wx5tasmser6jis6g
+  url: https://bitbucket.org/fenics-project/ffc/downloads/ffc-2016.1.0.tar.gz
 
 defaults:
   # share/ufc/UFCConfig.cmake contains hard-coded path

--- a/pkgs/ffc.yaml
+++ b/pkgs/ffc.yaml
@@ -1,7 +1,7 @@
-extends: [distutils_package]
+extends: [setuptools_package]
 dependencies:
-  build: [numpy, swig]
-  run: [fiat, instant, numpy, six, ufl]
+  build: [fiat, instant, numpy, six, ufl, swig]
+  run: [fiat, instant, numpy, six, ufl, swig]
 
 sources:
 - key: tar.gz:haxhoe76owljjzpqoudlcrho5llidylj

--- a/pkgs/fiat.yaml
+++ b/pkgs/fiat.yaml
@@ -1,6 +1,6 @@
 extends: [setuptools_package]
 dependencies:
-  build: []
+  build: [numpy, sympy]
   run: [numpy, sympy]
 
 sources:

--- a/pkgs/fiat.yaml
+++ b/pkgs/fiat.yaml
@@ -1,4 +1,4 @@
-extends: [setuptools_package]
+extends: [pip_package]
 dependencies:
   build: [numpy, sympy]
   run: [numpy, sympy]

--- a/pkgs/fiat.yaml
+++ b/pkgs/fiat.yaml
@@ -4,5 +4,5 @@ dependencies:
   run: [numpy, sympy]
 
 sources:
-- key: tar.gz:qwhkh2jwvu5tkwfuot74zlukpoo53ovp
-  url: https://bitbucket.org/fenics-project/fiat/downloads/fiat-1.6.0.tar.gz
+- key: tar.gz:qulsgetkog6bvyw4jllosmyl3g2u2uw3
+  url: https://bitbucket.org/fenics-project/fiat/downloads/fiat-2016.1.0.tar.gz

--- a/pkgs/host-pip.yaml
+++ b/pkgs/host-pip.yaml
@@ -1,0 +1,10 @@
+build_stages:
+- handler: bash
+  bash: |
+    mkdir -p ${ARTIFACT}/{{python_site_packages_rel}}
+    ln -s {{python_host_packages}}/pip ${ARTIFACT}/{{python_site_packages_rel}}
+
+profile_links:
+- name: python_packages
+  link: '{{python_site_packages_rel}}/*'
+  dirs: true

--- a/pkgs/host-py.yaml
+++ b/pkgs/host-py.yaml
@@ -1,0 +1,10 @@
+build_stages:
+- handler: bash
+  bash: |
+    mkdir -p ${ARTIFACT}/{{python_site_packages_rel}}
+    ln -s {{python_host_packages}}/py ${ARTIFACT}/{{python_site_packages_rel}}
+
+profile_links:
+- name: python_packages
+  link: '{{python_site_packages_rel}}/*'
+  dirs: true

--- a/pkgs/instant.yaml
+++ b/pkgs/instant.yaml
@@ -1,5 +1,6 @@
-extends: [distutils_package]
+extends: [setuptools_package]
 dependencies:
+  build: [numpy]
   run: [cmake, flufl_lock, numpy, swig]
 
 sources:

--- a/pkgs/instant.yaml
+++ b/pkgs/instant.yaml
@@ -1,4 +1,4 @@
-extends: [setuptools_package]
+extends: [pip_package]
 dependencies:
   build: [numpy]
   run: [cmake, flufl_lock, numpy, swig]

--- a/pkgs/instant.yaml
+++ b/pkgs/instant.yaml
@@ -4,5 +4,5 @@ dependencies:
   run: [cmake, flufl_lock, numpy, swig]
 
 sources:
-- key: tar.gz:end6aiuvggljbfmrd7nr3yyl2555274b
-  url: https://bitbucket.org/fenics-project/instant/downloads/instant-1.6.0.tar.gz
+- key: tar.gz:ppydzct3mh6r4qzlr45aibkbbltirexl
+  url: https://bitbucket.org/fenics-project/instant/downloads/instant-2016.1.0.tar.gz

--- a/pkgs/mshr.yaml
+++ b/pkgs/mshr.yaml
@@ -4,8 +4,8 @@ dependencies:
   build: [python, boost, dolfin, gmp, mpfr, mpi, swig, {{build_with}}]
 
 sources:
-- key: tar.gz:afm2l4z7m53oxkxxf4dsfxmth4jnxmsg
-  url: https://bitbucket.org/fenics-project/mshr/downloads/mshr-1.6.0.tar.gz
+- key: tar.gz:5ehq6cmiyeclibycpkxslq2h7jxjtrf7
+  url: https://bitbucket.org/fenics-project/mshr/downloads/mshr-2016.1.0.tar.gz
 
 defaults:
   # lib/CMake/mshr/mshr-config.cmake contains hard-coded path

--- a/pkgs/parmetis/parmetis.yaml
+++ b/pkgs/parmetis/parmetis.yaml
@@ -59,7 +59,10 @@ build_stages:
   before: configure
   handler: bash
   bash: |
-    CMAKE_FLAGS="${CMAKE_FLAGS} -DCMAKE_MACOSX_RPATH:BOOL=ON"
+    CMAKE_FLAGS="
+      ${CMAKE_FLAGS}
+      -DCMAKE_MACOSX_RPATH:BOOL=ON
+      -DCMAKE_OSX_SYSROOT:STRING=/"
 
 - name: configure
   after: cmake-flags

--- a/pkgs/petsc/petsc.py
+++ b/pkgs/petsc/petsc.py
@@ -117,8 +117,8 @@ def configure(ctx, stage_args):
         # Special case, no meaningful BLAS/LAPACK directories when using Accelerate
 
         if ctx.parameters['platform'] != 'Darwin':
-            conf_lines.append('--with-blas-dir=$BLAS_DIR')
-            conf_lines.append('--with-lapack-dir=$LAPACK_DIR')
+            conf_lines.append('--with-blas-lib=$BLAS_DIR/lib/libblas.so')
+            conf_lines.append('--with-lapack-lib=$LAPACK_DIR/lib/liblapack.so')
 
     # Special case, ParMETIS also provides METIS
     if 'PARMETIS' in ctx.dependency_dir_vars:

--- a/pkgs/petsc/petsc.yaml
+++ b/pkgs/petsc/petsc.yaml
@@ -1,6 +1,6 @@
 extends: [autotools_package]
 dependencies:
-  build: [blas, mpi, python, {{build_with}}]
+  build: [blas, lapack, mpi, python, {{build_with}}]
 
 when version == '3.6.1':
   sources:

--- a/pkgs/pip.yaml
+++ b/pkgs/pip.yaml
@@ -3,3 +3,7 @@ extends: [setuptools_package]
 sources:
 - key: tar.gz:gd4ywzxt7yigtrjjusivs7juuhbcjjug
   url: https://pypi.python.org/packages/source/p/pip/pip-8.0.3.tar.gz
+
+when_build_dependency:
+- prepend_path: PATH
+  value: '${ARTIFACT}/bin'

--- a/pkgs/pip.yaml
+++ b/pkgs/pip.yaml
@@ -1,9 +1,5 @@
 extends: [setuptools_package]
 
-dependencies:
-  build: []
-  run: []
-
 sources:
-- key: tar.gz:zichtbxqkkgpvf22ct5z67yqmjy5jygd
-  url: https://pypi.python.org/packages/source/p/pip/pip-7.1.2.tar.gz
+- key: tar.gz:gd4ywzxt7yigtrjjusivs7juuhbcjjug
+  url: https://pypi.python.org/packages/source/p/pip/pip-8.0.3.tar.gz

--- a/pkgs/py.yaml
+++ b/pkgs/py.yaml
@@ -1,5 +1,5 @@
 extends: [setuptools_package]
 
 sources:
-  - url: https://pypi.python.org/packages/source/p/py/py-1.4.20.tar.gz
-    key: tar.gz:epez3gplwkta5nychn2xpp6jrcwlacja
+- key: tar.gz:uzibsy6hex6ckvg2x7worlu2r626csoa
+  url: https://pypi.python.org/packages/source/p/py/py-1.4.31.tar.gz

--- a/pkgs/scipy/scipy.yaml
+++ b/pkgs/scipy/scipy.yaml
@@ -3,15 +3,19 @@ when platform != 'linux':
 when platform == 'linux':
   extends: [distutils_package, libflags]
 dependencies:
-  build: [lapack, numpy]
-  run: [lapack, numpy]
+  build: [blas, lapack, numpy]
+  run: [blas, lapack, numpy]
 
 sources:
   - url: http://downloads.sourceforge.net/scipy/scipy-0.13.3.tar.gz
     key: tar.gz:vhrty7xamdbvzvog5y5mtzpjxo4zegox
 
+defaults:
+  # Build with OpenBLAS
+  with_openblas: false
+
 build_stages:
-  - when: platform == 'linux'
+  - when: platform == 'linux' and not with_openblas
     name: set-lapack-paths
     after: libflags
     before: install
@@ -21,3 +25,24 @@ build_stages:
       export ATLAS=$LAPACK_DIR
       export BLAS=$LAPACK_DIR
       export LAPACK=$LAPACK_DIR
+
+  - when: platform == 'linux' and with_openblas
+    name: set-lapack-paths
+    after: libflags
+    before: install
+    handler: bash
+    bash: |
+      export LDFLAGS="-shared -Wl,-rpath=${PYTHON_DIR}/lib -Wl,-rpath=${BLAS_DIR}/lib $(${PYTHON_DIR}/bin/python-config --ldflags)"
+      #export ATLAS=None
+      export LAPACK=${BLAS_DIR}/lib/libopenblas.so
+      export BLAS=${BLAS_DIR}/lib/libopenblas.so
+
+# Make sure that the fortran objects are compiled with -fPIC
+  - when: platform == 'linux'
+    name: compile-fc-with-fPIC
+    after: setup_dirs
+    before: install
+    handler: bash
+    bash: |
+      export FFLAGS="$FFLAGS -fPIC"
+      export FCFLAGS="$FCFLAGS -fPIC"

--- a/pkgs/setuptools.yaml
+++ b/pkgs/setuptools.yaml
@@ -18,8 +18,8 @@ build_stages:
       ${PYTHON} setup.py install --prefix=. --root=${ARTIFACT}/Python.framework/Versions/{{pyver}} --single-version-externally-managed
 
 sources:
-  - url: https://pypi.python.org/packages/source/s/setuptools/setuptools-3.4.3.tar.gz
-    key: tar.gz:yfr3o4jkjyuvq7cmwfn52gmjt7xmiopn
+- key: tar.gz:ezr44cyooqxoe7b2a2znufcwhzhw64j6
+  url: https://pypi.python.org/packages/source/s/setuptools/setuptools-20.1.1.tar.gz
 
 when_build_dependency:
   - when: not python_framework

--- a/pkgs/ufl.yaml
+++ b/pkgs/ufl.yaml
@@ -1,6 +1,6 @@
-extends: [distutils_package]
+extends: [setuptools_package]
 dependencies:
-  build: []
+  build: [numpy, six]
   run: [numpy, six]
 
 sources:

--- a/pkgs/ufl.yaml
+++ b/pkgs/ufl.yaml
@@ -1,4 +1,4 @@
-extends: [setuptools_package]
+extends: [pip_package]
 dependencies:
   build: [numpy, six]
   run: [numpy, six]

--- a/pkgs/ufl.yaml
+++ b/pkgs/ufl.yaml
@@ -4,5 +4,5 @@ dependencies:
   run: [numpy, six]
 
 sources:
-- key: tar.gz:y5oepapfcbcqj4kyznbm3b5m575jauxi
-  url: https://bitbucket.org/fenics-project/ufl/downloads/ufl-1.6.0.tar.gz
+- key: tar.gz:rxgp4egreun2jcsniosmnse2xydwhebc
+  url: https://bitbucket.org/fenics-project/ufl/downloads/ufl-2016.1.0.tar.gz

--- a/pkgs/uflacs.yaml
+++ b/pkgs/uflacs.yaml
@@ -1,7 +1,7 @@
-extends: [distutils_package]
+extends: [setuptools_package]
 dependencies:
-  build: []
-  run: [ffc, numpy, six, ufl]
+  build: [numpy, six, ufl]
+  run: [numpy, six, ufl]
 
 sources:
 - key: tar.gz:x2ybjis6ms5zjw3hodnelft2gsq32t4x

--- a/pkgs/vtk/vtk.yaml
+++ b/pkgs/vtk/vtk.yaml
@@ -1,8 +1,9 @@
 extends: [cmake_package]
 dependencies:
   build:
-    - python
-    - setuptools
+    - when vtk_wrap_python:
+        - python
+        - setuptools
     - libtiff
     - when platform == 'linux':
         - patchelf
@@ -17,10 +18,11 @@ defaults:
   # lib/vtk-5.10/libvtkHybrid.so.5.10.1 contains hard-coded path
   relocatable: false
   vtk_use_tk: false
+  vtk_wrap_python: true
 
 build_stages:
-
-- name: setup_dirs
+- when: vtk_wrap_python
+  name: setup_dirs
   after: prologue
   before: setup_builddir
   handler: bash
@@ -56,12 +58,9 @@ build_stages:
     - '-D BUILD_TESTING:BOOL=OFF'
     - '-D BUILD_EXAMPLES:BOOL=OFF'
     - '-D BUILD_SHARED_LIBS:BOOL=ON'
-    - '-D VTK_WRAP_PYTHON:BOOL=ON'
     - '-D VTK_WRAP_TCL:BOOL=OFF'
     - '-D VTK_USE_GL2PS:BOOL=ON'
-    - '-D VTK_PYTHON_SETUP_ARGS:STRING="--prefix=. --root=${ARTIFACT} --single-version-externally-managed"'
     - '-D CMAKE_INSTALL_RPATH:STRING="${ARTIFACT}/lib/vtk-5.10"'
-    - '-D PYTHON_EXECUTABLE:FILEPATH="${PYTHON}"'
     - '-D VTK_USE_SYSTEM_TIFF:BOOL=ON'
 
 - when: vtk_use_tk
@@ -74,7 +73,19 @@ build_stages:
   mode: update
   extra: ['-D VTK_USE_TK:BOOL=OFF']
 
-- when: platform == 'linux'
+- when: vtk_wrap_python
+  name: configure
+  mode: update
+  extra: ['-D VTK_WRAP_PYTHON:BOOL=ON',
+          '-D VTK_PYTHON_SETUP_ARGS:STRING="--prefix=. --root=${ARTIFACT} --single-version-externally-managed"',
+          '-D PYTHON_EXECUTABLE:FILEPATH="${PYTHON}"']
+
+- when: not vtk_wrap_python
+  name: configure
+  mode: update
+  extra: ['-D VTK_WRAP_PYTHON:BOOL=OFF']
+
+- when: platform == 'linux' and vtk_wrap_python
   name: rpath_fix
   after: install
   handler: bash
@@ -103,15 +114,18 @@ build_stages:
     done
 
 profile_links:
-- name: python_packages
+- when: vtk_wrap_python
+  name: python_packages
   link: 'lib/python{{pyver}}/site-packages/*'
   dirs: true
 
-- name: python_exclude
+- when: vtk_wrap_python
+  name: python_exclude
   after: python_packages
   before: everything
   exclude: 'lib/python{{pyver}}/site-packages/**/*'
 
 when_build_dependency:
-- prepend_path: PYTHONPATH
+- when: vtk_wrap_python
+  prepend_path: PYTHONPATH
   value: '${ARTIFACT}/lib/python{{pyver}}/site-packages'


### PR DESCRIPTION
* Update FEniCS to latest version 2016.1
* Explicitly add parameter `empty_osx_deployment_target` in base cmake package
* Add parameter `cmake_osx_sysroot` in base cmake package
* Add base package for installing python packages using pip
* Use cython tarball from github (old url broken)
* Add new FEniCS package `dijitso`
* Use `install_name_tool` to fix rpath for `dolfin` on macOS 
* Add host packages for `py` and `pip`
* Add `lapack` to build dependencies for `petsc`
* Upgrade `pip` to version 8.0.3
* Add `blas` to dependencies for `scipy`
* Add parameter `with_openblas` to `scipy` for building with `openblas` (default is `false`)
* Add parameter `vtk_wrap_python` to allow `vtk` to be built without python interface