### PR TITLE
Update to Cython 0.24.1

### DIFF
--- a/pkgs/cython.yaml
+++ b/pkgs/cython.yaml
@@ -1,8 +1,8 @@
 extends: [distutils_package]
 
 sources:
-- key: tar.gz:lebhjlenxupgftdz3fhlfyxuvzqm5ki2
-  url: http://cython.org/release/Cython-0.23.3.tar.gz
+- key: tar.gz:qsai7wqakcdvpeuod7vnz5a4t54otknx
+  url: https://pypi.python.org/packages/c6/fe/97319581905de40f1be7015a0ea1bd336a756f6249914b148a17eefa75dc/Cython-0.24.1.tar.gz
 
 when_build_dependency:
   - prepend_path: PATH


### PR DESCRIPTION
The previous download url does not work any more, and cython.org had a major service interruption a month ago. Use the pypi download url instead.