### PR TITLE
stable/proteus: updated yaml files of pkgs for gcc 6 compilation

### DIFF
--- a/pkgs/chrono.yaml
+++ b/pkgs/chrono.yaml
@@ -2,7 +2,7 @@ extends: [cmake_package]
 
 sources:
 - url: https://github.com/projectchrono/chrono.git
-  key: git:a181c70e4ae83bd698e0e96e853c9a73636ccf4f
+  key: git:c287bd6010fbac79b0546634499c971875423d50
 
 defaults:
   relocatable: false

--- a/pkgs/geos.yaml
+++ b/pkgs/geos.yaml
@@ -1,8 +1,8 @@
 extends: [autotools_package]
 
 sources:
-  - url: http://download.osgeo.org/geos/geos-3.4.2.tar.bz2
-    key: tar.bz2:cxul7x36feehvfl3k2wfipvjvabscsa4
+    - url: http://download.osgeo.org/geos/geos-3.6.0.tar.bz2
+      key: tar.bz2:d7twitzsideeekybiobq74kc4rhiwajt
 
 when_build_dependency:
   - prepend_path: PATH

--- a/pkgs/irrlicht/irrlicht.yaml
+++ b/pkgs/irrlicht/irrlicht.yaml
@@ -1,8 +1,8 @@
 extends: [autotools_package]
 
 sources:
-- key: zip:tz56iqtxx4qajvzvqcufqxt32pe45gr4
-  url: http://sourceforge.net/projects/irrlicht/files/Irrlicht%20SDK/1.8/1.8.3/irrlicht-1.8.3.zip
+  - url: http://sourceforge.net/projects/irrlicht/files/Irrlicht%20SDK/1.8/1.8.4/irrlicht-1.8.4.zip
+    key: zip:6qvsqc6gbdsulobaebx6fkmzyvpssdpf
   
 dependencies:
   build:

--- a/pkgs/perl.yaml
+++ b/pkgs/perl.yaml
@@ -8,7 +8,7 @@ dependencies:
 
 sources:
 - key: tar.gz:j2gcrllozsezal44wltw6kavxmnifb66
-  url: http://www.cpan.org/src/5.0/perl-5.20.0.tar.gz
+  url: http://www.cpan.org/src/5.0/perl-5.24.0.tar.gz
 
 build_stages:
 - name: configure

--- a/pkgs/python-netcdf4.yaml
+++ b/pkgs/python-netcdf4.yaml
@@ -4,8 +4,8 @@ dependencies:
   run: [netcdf4, numpy]
 
 sources:
-  - url: http://netcdf4-python.googlecode.com/files/netCDF4-1.0.4.tar.gz
-    key: tar.gz:th26v25of6xje5m5co3zbxpeejvsxded
+  - url: https://github.com/Unidata/netcdf4-python/archive/v1.2.4rel.tar.gz
+    key: tar.gz:6o4bwxm7ekc62jzpoltywfzryiiq7ggl
 
 build_stages:
 - name: set_mpi_wrapper

--- a/pkgs/readline.yaml
+++ b/pkgs/readline.yaml
@@ -3,8 +3,8 @@ dependencies:
   build: [ncurses]
 
 sources:
-  - url: http://ftp.gnu.org/gnu/readline/readline-6.2.tar.gz
-    key: tar.gz:pgtjmbykawgcgpds3vvmnfycdtdevpk6
+  - url: http://ftp.gnu.org/gnu/readline/readline-6.3.tar.gz
+    key: tar.gz:k25ga4nziyxzqdc2okvqai4jhns3u3pl
 
 build_stages:
   - name: configure


### PR DESCRIPTION
A couple of packages updates for compiling with gcc 6.2.1 (using arch linux).
When compiling with gcc 6, zoltan can to be commented out in `examples/proteus.linux2.yaml` as the current version throws an error