### PR TITLE
Add patch required to build gettext-bootstrap on Cygwin.

### DIFF
--- a/pkgs/gettext-bootstrap/cygwin.patch
+++ b/pkgs/gettext-bootstrap/cygwin.patch
@@ -1,0 +1,37 @@
+Patch incompatibility between gnulib headers and Cygwin (or, more generally,
+newlib) as originally reported at
+https://lists.gnu.org/archive/html/bug-gnulib/2016-03/msg00054.html
+
+diff --git a/gettext-tools/gnulib-lib/sys_select.in.h b/gettext-tools/gnulib-lib/sys_select.in.h
+index d6d3f9f..7281144 100644
+--- a/gettext-tools/gnulib-lib/sys_select.in.h
++++ b/gettext-tools/gnulib-lib/sys_select.in.h
+@@ -81,8 +81,9 @@
+    of 'struct timeval', and no definition of this type.
+    Also, Mac OS X, AIX, HP-UX, IRIX, Solaris, Interix declare select()
+    in <sys/time.h>.
+-   But avoid namespace pollution on glibc systems.  */
+-# ifndef __GLIBC__
++   But avoid namespace pollution on glibc systems and "unknown type
++   name" problems on Cygwin.  */
++# if !(defined __GLIBC__ || defined __CYGWIN__)
+ #  include <sys/time.h>
+ # endif
+ 
+@@ -100,10 +101,11 @@
+ #endif
+ 
+ /* Get definition of 'sigset_t'.
+-   But avoid namespace pollution on glibc systems.
++   But avoid namespace pollution on glibc systems and "unknown type
++   name" problems on Cygwin.
+    Do this after the include_next (for the sake of OpenBSD 5.0) but before
+    the split double-inclusion guard (for the sake of Solaris).  */
+-#if !(defined __GLIBC__ && !defined __UCLIBC__)
++#if !((defined __GLIBC__ || defined __CYGWIN__) && !defined __UCLIBC__)
+ # include <signal.h>
+ #endif
+ 
+-- 
+2.5.0
+

--- a/pkgs/gettext-bootstrap/gettext-bootstrap.yaml
+++ b/pkgs/gettext-bootstrap/gettext-bootstrap.yaml
@@ -7,6 +7,15 @@ defaults:
   # /share/doc/gettext/examples/installpaths contains absolute path
   relocatable: false
 
+build_stages:
+  - when: platform == 'Cygwin'
+    name: patch
+    before: configure
+    files: [cygwin.patch]
+    handler: bash
+    bash: |
+      patch -up1 < _hashdist/cygwin.patch
+
 sources:
 - url: http://ftp.gnu.org/pub/gnu/gettext/gettext-0.19.1.tar.gz
   key: tar.gz:fb2hdwk335p6wsdcmjd73rjqmyhd2kig


### PR DESCRIPTION
Other packages likely require this patch as well, but I will add it as I find them--basically it's needed for anything that tries to compile with gnulib on Cygwin.