### PR TITLE
Add patch for sqlite for config.guess to properly identify Cygwin-64 …

### DIFF
--- a/pkgs/sqlite.yaml
+++ b/pkgs/sqlite.yaml
@@ -1,7 +1,0 @@
-extends: [autotools_package]
-dependencies:
-  build: [readline]
-
-sources:
-  - url: https://sqlite.org/2013/sqlite-autoconf-3071700.tar.gz
-    key: tar.gz:r72g2c5ktzsmbakvituct2mf6elbyclk

--- a/pkgs/sqlite/cygwin_config_guess.patch
+++ b/pkgs/sqlite/cygwin_config_guess.patch
@@ -1,0 +1,12 @@
+--- a/config.guess	2016-11-30 15:12:41.668793100 +0100
++++ b/config.guess	2016-11-30 15:13:49.883718600 +0100
+@@ -797,6 +797,9 @@
+     amd64:CYGWIN*:*:*)
+ 	echo x86_64-unknown-cygwin
+ 	exit ;;
++    x86_64:CYGWIN*:*:*)
++	echo x86_64-unknown-cygwin
++	exit ;;
+     p*:CYGWIN*:*)
+ 	echo powerpcle-unknown-cygwin
+ 	exit ;;

--- a/pkgs/sqlite/sqlite.yaml
+++ b/pkgs/sqlite/sqlite.yaml
@@ -1,0 +1,16 @@
+extends: [autotools_package]
+dependencies:
+  build: [readline]
+
+build_stages:
+  - when: platform == 'Cygwin'
+    name: patch
+    before: configure
+    files: [cygwin_config_guess.patch]
+    handler: bash
+    bash: |
+      patch -up1 < _hashdist/cygwin_config_guess.patch
+
+sources:
+  - url: https://sqlite.org/2013/sqlite-autoconf-3071700.tar.gz
+    key: tar.gz:r72g2c5ktzsmbakvituct2mf6elbyclk


### PR DESCRIPTION
…when `uname -m` returns `'x84_64'`

Tried to do this without a patch--in princple this could be fixed by passing the correct --build flag
to configure, but it was too tricky to do that on a conditional basis.

This could also be fixed by giving sqlite a newer `config.guess` entirely but it's easy enough to add this one small patch.