### PR TITLE
Patch gdbm on Cygwin so that it can build a shared library

### DIFF
--- a/pkgs/gdbm.yaml
+++ b/pkgs/gdbm.yaml
@@ -1,8 +1,0 @@
-extends: [autotools_package]
-
-defaults:
-  relocatable: false
-
-sources:
-- key: tar.gz:rwis6rhqlufrljff3fvhn6cs5ec5aun3
-  url: http://ftp.heanet.ie/mirrors/gnu/gdbm/gdbm-1.11.tar.gz

--- a/pkgs/gdbm/gdbm-cygwin.patch
+++ b/pkgs/gdbm/gdbm-cygwin.patch
@@ -1,0 +1,24 @@
+diff -ruN a/src/Makefile.am b/src/Makefile.am
+--- a/src/Makefile.am	2013-05-21 13:17:36.000000000 +0200
++++ b/src/Makefile.am	2016-12-06 17:31:14.234051600 +0100
+@@ -65,7 +65,7 @@
+  update.c\
+  version.c
+ 
+-libgdbm_la_LDFLAGS = -version-info $(VI_CURRENT):$(VI_REVISION):$(VI_AGE)
++libgdbm_la_LDFLAGS = -no-undefined -version-info $(VI_CURRENT):$(VI_REVISION):$(VI_AGE)
+ 
+ noinst_LIBRARIES = libgdbmapp.a
+ 
+diff -ruN a/src/Makefile.in b/src/Makefile.in
+--- a/src/Makefile.in	2013-12-25 16:58:27.000000000 +0100
++++ b/src/Makefile.in	2016-12-06 17:31:28.344073600 +0100
+@@ -461,7 +461,7 @@
+  update.c\
+  version.c
+ 
+-libgdbm_la_LDFLAGS = -version-info $(VI_CURRENT):$(VI_REVISION):$(VI_AGE)
++libgdbm_la_LDFLAGS = -no-undefined -version-info $(VI_CURRENT):$(VI_REVISION):$(VI_AGE)
+ noinst_LIBRARIES = libgdbmapp.a
+ libgdbmapp_a_SOURCES = \
+  err.c\

--- a/pkgs/gdbm/gdbm.yaml
+++ b/pkgs/gdbm/gdbm.yaml
@@ -1,0 +1,17 @@
+extends: [autotools_package]
+
+defaults:
+  relocatable: false
+
+build_stages:
+  - when: platform == 'Cygwin'
+    name: patch
+    before: configure
+    files: [gdbm-cygwin.patch]
+    handler: bash
+    bash: |
+      patch -up1 < _hashdist/gdbm-cygwin.patch
+
+sources:
+- key: tar.gz:rwis6rhqlufrljff3fvhn6cs5ec5aun3
+  url: http://ftp.heanet.ie/mirrors/gnu/gdbm/gdbm-1.11.tar.gz


### PR DESCRIPTION
Title pretty much says it all.  This patch is quick and dirty since it's only applied on Cygwin, but without it gdbm does not build a shared library on Cygwin.