### PR TITLE
Build Python 2.7 with UCS-4 enabled

### DIFF
--- a/pkgs/python/python.yaml
+++ b/pkgs/python/python.yaml
@@ -73,6 +73,11 @@ build_stages:
     mode: update
     extra: ['--without-ensurepip']
 
+  - when: pyver == '2.7'
+    name: configure
+    mode: update
+    extra: ['--enable-unicode=ucs4']
+
   - when: python_framework
     name: configure
     mode: update


### PR DESCRIPTION
Without it, Python cannot handle regular expressions involving 4-byte
unicode chars. This is also the default in Python >= 3.3

I just tripped over this:
~~~~
In [1]: import re
In [2]: re.compile(u'[\U00010000-\U0010ffff]')
error: bad character range
~~~~
Whereas it works with the system python2 and python3 on Fedora, probably all other distros too. 