### PR TITLE
Update to git-2.12.0

### DIFF
--- a/pkgs/git.yaml
+++ b/pkgs/git.yaml
@@ -4,8 +4,8 @@ dependencies:
   build: [curl, pcre, openssl, libiconv, gettext, expat, zlib, perl]
 
 sources:
-- key: tar.gz:2wghm2ua3bvf4gcgybghiymotc76yfmh
-  url: https://www.kernel.org/pub/software/scm/git/git-2.4.0.tar.gz
+- key: tar.gz:raxstdnplavaprmxon7ljo5pxawgech6
+  url: https://www.kernel.org/pub/software/scm/git/git-2.12.0.tar.gz
 
 defaults:
   # /bin/git contains hard-coded path


### PR DESCRIPTION
The old git 2.4.0 doesn't compile on osx sierra any more, fixed in the latest and greatest
~~~~
2017/03/05 23:49:32 - INFO: [package:run_job]     AR xdiff/lib.a
2017/03/05 23:49:32 - INFO: [package:run_job]     LINK git-credential-store
2017/03/05 23:49:32 - INFO: [package:run_job] ld: library not found for -lrt
2017/03/05 23:49:32 - INFO: [package:run_job] clang: error: linker command failed with exit code 1 (use -v to see invocation)
2017/03/05 23:49:32 - INFO: [package:run_job] make: *** [git-credential-store] Error 1
~~~~