### PR TITLE
Change zeromq download url to github

### DIFF
--- a/pkgs/zmq.yaml
+++ b/pkgs/zmq.yaml
@@ -1,8 +1,8 @@
 extends: [autotools_package]
 
 sources:
-- key: tar.gz:mgzrzaynwn3xo7sboi22etjwmcslzq7u
-  url: http://download.zeromq.org/zeromq-4.1.3.tar.gz
+- key: tar.gz:alv7mcsdaephob4zgnrwlpf44lvykvu6
+  url: https://github.com/zeromq/zeromq4-1/releases/download/v4.1.6/zeromq-4.1.6.tar.gz
 
 build_stages:
 - name: configure


### PR DESCRIPTION
The old zeromq download url is apparently defunct. While we are at it,
update to the latest legacy stable release.