### PR TITLE
re-updated chrono commit

### DIFF
--- a/pkgs/chrono/chrono.yaml
+++ b/pkgs/chrono/chrono.yaml
@@ -1,8 +1,8 @@
 extends: [cmake_package]
 
 sources:
-- key: tar.gz:o4ix5dbxuopgassafyck3rwor7sue4f4
-  url: https://github.com/projectchrono/chrono/archive/00e5309ba0d0eccf59c1054f36f1f77a55926397.tar.gz
+- key: tar.gz:iwcb6fdcl5giixomenbp4pmdezpyuray
+  url: https://github.com/projectchrono/chrono/archive/19c1e5565c0de43579aef356a1b311860da58ad8.tar.gz
 
 defaults:
   relocatable: false


### PR DESCRIPTION
@cekees, the updated chrono commit was reverted to an older version when the yaml file moved in a subfolder on commit 01d45467b8cc60ddb51878a7a73a722fd5abbdfd